### PR TITLE
feat: Add a gpt-neox image with MPI support

### DIFF
--- a/.github/workflows/gpt-neox-mpi.yml
+++ b/.github/workflows/gpt-neox-mpi.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "gpt-neox-mpi/**"
+      - ".github/workflows/gpt-neox-mpi.yml"
+      - ".github/workflows/build.yml"
+
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      image-name: gpt-neox-mpi
+      folder: gpt-neox-mpi
+      build-args: ""

--- a/gpt-neox-mpi/Dockerfile
+++ b/gpt-neox-mpi/Dockerfile
@@ -1,0 +1,76 @@
+FROM nvidia/cuda:11.1.1-devel-ubuntu20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+#### System package (uses default Python 3 version in Ubuntu 20.04)
+RUN apt-get update -y && \
+    apt-get install -y \
+        git python3 python3-dev libpython3-dev python3-pip sudo pdsh \
+        htop llvm-9-dev tmux zstd software-properties-common build-essential autotools-dev \
+        nfs-common pdsh cmake g++ gcc curl wget vim less unzip htop iftop iotop ca-certificates ssh \
+        rsync iputils-ping net-tools libcupti-dev libmlx4-1 infiniband-diags ibutils ibverbs-utils \
+        rdmacm-utils perftest rdma-core nano && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
+    pip install --upgrade pip && \
+    pip install gpustat
+
+#### OPENMPI
+ENV OPENMPI_BASEVERSION=4.1
+ENV OPENMPI_VERSION=${OPENMPI_BASEVERSION}.0
+RUN mkdir -p /build && \
+    cd /build && \
+    wget -q -O - https://download.open-mpi.org/release/open-mpi/v${OPENMPI_BASEVERSION}/openmpi-${OPENMPI_VERSION}.tar.gz | tar xzf - && \
+    cd openmpi-${OPENMPI_VERSION} && \
+    ./configure --prefix=/usr/local/openmpi-${OPENMPI_VERSION} && \
+    make -j"$(nproc)" install && \
+    ln -s /usr/local/openmpi-${OPENMPI_VERSION} /usr/local/mpi && \
+    # Sanity check:
+    test -f /usr/local/mpi/bin/mpic++ && \
+    cd ~ && \
+    rm -rf /build
+
+# Needs to be in docker PATH if compiling other items & bashrc PATH (later)
+ENV PATH=/usr/local/mpi/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/lib:/usr/local/mpi/lib:/usr/local/mpi/lib64:${LD_LIBRARY_PATH}
+
+# Create a wrapper for OpenMPI to allow running as root by default
+RUN mv /usr/local/mpi/bin/mpirun /usr/local/mpi/bin/mpirun.real && \
+    echo '#!/bin/bash' > /usr/local/mpi/bin/mpirun && \
+    echo 'mpirun.real --allow-run-as-root --prefix /usr/local/mpi "$@"' >> /usr/local/mpi/bin/mpirun && \
+    chmod a+x /usr/local/mpi/bin/mpirun
+
+#### Python packages
+RUN pip install torch==1.8.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && pip cache purge
+
+# Install yq
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq;
+
+# SSH dependencies for MPI
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    mkdir /var/run/sshd -p
+
+## Install APEX
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@a651e2c24ecf97cbf367fd3f330df36760e1c597
+
+# Get the gpt-neox source code
+RUN git clone https://github.com/EleutherAI/gpt-neox.git
+
+# Use the-eye.eu instead of the dead mystic.the-eye.eu mirror for dataset links
+RUN sed -i 's/mystic.the-eye/the-eye/g' /gpt-neox/tools/corpora.py
+
+RUN pip install -r /gpt-neox/requirements/requirements.txt && \
+    pip install -r /gpt-neox/requirements/requirements-onebitadam.txt && \
+    pip install -r /gpt-neox/requirements/requirements-sparseattention.txt && \
+    pip install protobuf==3.20.* && \
+    pip install git+https://github.com/EleutherAI/best-download.git && \
+    pip cache purge
+
+RUN python /gpt-neox/megatron/fused_kernels/setup.py install
+
+# Clear staging
+RUN mkdir -p /tmp && chmod 0777 /tmp
+
+WORKDIR /gpt-neox


### PR DESCRIPTION
These changes add a new docker image that will be used in a kubeflow training operator example for finetuning GPT-NeoX-20B.

The Dockerfile has been used to build the image `navarrepratt/ml-containers:gpt-neox-2` which has been tested on the example code in this [kubernetes-cloud PR](https://github.com/coreweave/kubernetes-cloud/pull/131)