### PR TITLE
update(gpt-neox-mpi): Update cuda and apex versions

### DIFF
--- a/gpt-neox-mpi/Dockerfile
+++ b/gpt-neox-mpi/Dockerfile
@@ -1,62 +1,26 @@
-FROM nvidia/cuda:11.7.0-devel-ubuntu20.04
+FROM ghcr.io/coreweave/nccl-tests:11.7.1-devel-ubuntu20.04-nccl2.14.3-1-a0cb1a6
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 #### System package (uses default Python 3 version in Ubuntu 20.04)
 RUN apt-get update -y && \
     apt-get install -y \
-        git python3 python3-dev libpython3-dev python3-pip sudo pdsh \
-        htop llvm-9-dev tmux zstd software-properties-common build-essential autotools-dev \
-        nfs-common pdsh cmake g++ gcc curl wget vim less unzip htop iftop iotop ca-certificates ssh \
-        rsync iputils-ping net-tools libcupti-dev libmlx4-1 infiniband-diags ibutils ibverbs-utils \
-        rdmacm-utils perftest rdma-core nano && \
+        git python3 python3-dev libpython3-dev python3-pip pdsh && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
     pip install --upgrade pip && \
     pip install gpustat
 
-#### OPENMPI
-ENV OPENMPI_BASEVERSION=4.1
-ENV OPENMPI_VERSION=${OPENMPI_BASEVERSION}.0
-RUN mkdir -p /build && \
-    cd /build && \
-    wget -q -O - https://download.open-mpi.org/release/open-mpi/v${OPENMPI_BASEVERSION}/openmpi-${OPENMPI_VERSION}.tar.gz | tar xzf - && \
-    cd openmpi-${OPENMPI_VERSION} && \
-    ./configure --prefix=/usr/local/openmpi-${OPENMPI_VERSION} && \
-    make -j"$(nproc)" install && \
-    ln -s /usr/local/openmpi-${OPENMPI_VERSION} /usr/local/mpi && \
-    # Sanity check:
-    test -f /usr/local/mpi/bin/mpic++ && \
-    cd ~ && \
-    rm -rf /build
-
-# Needs to be in docker PATH if compiling other items & bashrc PATH (later)
-ENV PATH=/usr/local/mpi/bin:${PATH} \
-    LD_LIBRARY_PATH=/usr/local/lib:/usr/local/mpi/lib:/usr/local/mpi/lib64:${LD_LIBRARY_PATH}
-
-# Create a wrapper for OpenMPI to allow running as root by default
-RUN mv /usr/local/mpi/bin/mpirun /usr/local/mpi/bin/mpirun.real && \
-    echo '#!/bin/bash' > /usr/local/mpi/bin/mpirun && \
-    echo 'mpirun.real --allow-run-as-root --prefix /usr/local/mpi "$@"' >> /usr/local/mpi/bin/mpirun && \
-    chmod a+x /usr/local/mpi/bin/mpirun
-
 #### Python packages
 RUN pip install torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch_stable.html && \
     pip install packaging>=14.0 && pip cache purge
 
-# Install yq
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq;
-
-# SSH dependencies for MPI
-RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
-    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
-    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
-    mkdir /var/run/sshd -p
-
 ## Install APEX
-RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@537424d24d55e3a166c930828e4780549edc6151
+ARG APEX_COMMIT=537424d24d55e3a166c930828e4780549edc6151
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@${APEX_COMMIT}
 
 # Get the gpt-neox source code
+WORKDIR /
 RUN git clone https://github.com/EleutherAI/gpt-neox.git
 
 # Use the-eye.eu instead of the dead mystic.the-eye.eu mirror for dataset links

--- a/gpt-neox-mpi/Dockerfile
+++ b/gpt-neox-mpi/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.7.0-devel-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,7 +41,8 @@ RUN mv /usr/local/mpi/bin/mpirun /usr/local/mpi/bin/mpirun.real && \
     chmod a+x /usr/local/mpi/bin/mpirun
 
 #### Python packages
-RUN pip install torch==1.8.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && pip cache purge
+RUN pip install torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch_stable.html && \
+    pip install packaging>=14.0 && pip cache purge
 
 # Install yq
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq;
@@ -53,7 +54,7 @@ RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config &&
     mkdir /var/run/sshd -p
 
 ## Install APEX
-RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@a651e2c24ecf97cbf367fd3f330df36760e1c597
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@537424d24d55e3a166c930828e4780549edc6151
 
 # Get the gpt-neox source code
 RUN git clone https://github.com/EleutherAI/gpt-neox.git

--- a/gpt-neox-mpi/Dockerfile
+++ b/gpt-neox-mpi/Dockerfile
@@ -17,7 +17,8 @@ RUN pip install torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch_st
 
 ## Install APEX
 ARG APEX_COMMIT=537424d24d55e3a166c930828e4780549edc6151
-RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@${APEX_COMMIT}
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" \
+        --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@${APEX_COMMIT}
 
 # Get the gpt-neox source code
 WORKDIR /


### PR DESCRIPTION
The original ElutherAI gpt-neox images used an older CUDA base image along with older versions of torch and apex. This wasn't leading to any problems at first, but I noticed that there would be a NCCL error thrown whenever a worker would run on a `g99*` A100 NVLINK 80gb node. Once I upgraded the versions I would no longer see the NCCL error on those nodes.

NCCL Error:
```
NCCL error in: /pytorch/torch/lib/c10d/ProcessGroupNCCL.cpp:825, unhandled system error, NCCL version 2.7.8
```

Two specific nodes that I know threw these errors:
- g9963e2
- g99645a
