### PR TITLE
fix: Change build args to list of strings

### DIFF
--- a/.github/workflows/sd-finetuner.yml
+++ b/.github/workflows/sd-finetuner.yml
@@ -18,4 +18,5 @@ jobs:
     with: 
       image-name: sd-finetuner
       folder: sd-finetuner
-      build-args: "--build-arg COMMIT=${{ github.event.inputs.commit }}"
+      build-args: |
+        COMMIT=${{ github.event.inputs.commit }}

--- a/.github/workflows/sd-inference.yml
+++ b/.github/workflows/sd-inference.yml
@@ -18,4 +18,5 @@ jobs:
     with: 
       image-name: sd-inference
       folder: sd-inference
-      build-args: "--build-arg COMMIT=${{ github.event.inputs.commit }}"
+      build-args: |
+        COMMIT=${{ github.event.inputs.commit }}

--- a/.github/workflows/sd-serializer.yml
+++ b/.github/workflows/sd-serializer.yml
@@ -18,4 +18,5 @@ jobs:
     with: 
       image-name: sd-serializer
       folder: sd-serializer
-      build-args: "--build-arg COMMIT=${{ github.event.inputs.commit }}"
+      build-args: |
+        COMMIT=${{ github.event.inputs.commit }}


### PR DESCRIPTION
The build-args should be passed in as a [new-line delimted list of strings](https://github.com/docker/build-push-action#inputs), like in the `slurm.yml` workload. Without these changes, the action wasn't properly passing in the commit and would use the cached layer when building the docker image instead of pulling down the new changes from `kuberenetes-cloud`.

[Build using cached layers instead of pulling `kubernetes-cloud`](https://github.com/coreweave/ml-containers/actions/runs/4185560732/jobs/7252784473#step:8:142)
[Build with this fix properly pulling down `kubernetes-cloud`](https://github.com/coreweave/ml-containers/actions/runs/4185810558/jobs/7253398541#step:8:200)