### PR TITLE
fix: Move COMMIT arg into build stage

### DIFF
--- a/sd-finetuner/Dockerfile
+++ b/sd-finetuner/Dockerfile
@@ -1,4 +1,3 @@
-ARG COMMIT=master
 FROM gooseai/torch-base:6cfdc11
 
 RUN apt-get install -y cuda-nvcc-11-3 cuda-nvml-dev-11-3 libcurand-dev-11-3 \
@@ -10,6 +9,7 @@ RUN apt-get install -y cuda-nvcc-11-3 cuda-nvml-dev-11-3 libcurand-dev-11-3 \
 RUN mkdir /app
 WORKDIR /app
 
+ARG COMMIT=master
 RUN git clone https://github.com/coreweave/kubernetes-cloud.git && \
     cd kubernetes-cloud && \
     git checkout ${COMMIT} && \

--- a/sd-inference/Dockerfile
+++ b/sd-inference/Dockerfile
@@ -1,4 +1,3 @@
-ARG COMMIT=master
 FROM gooseai/torch-base:1.13.1-cuda-1.18-rc4
 
 ENV tenzorizer_commit=35381e3812ba342991d30b71ce257503622ae828
@@ -6,6 +5,7 @@ ENV tenzorizer_commit=35381e3812ba342991d30b71ce257503622ae828
 RUN mkdir /app
 WORKDIR /app
 
+ARG COMMIT=master
 RUN git clone https://github.com/coreweave/kubernetes-cloud && \
     cd kubernetes-cloud && \
     git checkout ${COMMIT} && \

--- a/sd-serializer/Dockerfile
+++ b/sd-serializer/Dockerfile
@@ -1,4 +1,3 @@
-ARG COMMIT=master
 FROM python:3.9
 
 RUN mkdir /app
@@ -6,6 +5,7 @@ WORKDIR /app
 
 ENV tenzorizer_commit=35381e3812ba342991d30b71ce257503622ae828
 
+ARG COMMIT=master
 RUN git clone https://github.com/coreweave/kubernetes-cloud && \
     cd kubernetes-cloud && \
     git checkout ${COMMIT} && \


### PR DESCRIPTION
Adding the COMMIT ARG before the `FROM` causes the build to use the cache for all layers even when the kubernetes-cloud code has changed. This is because:

> An ARG declared before a FROM is outside of a build stage, so it can’t be used in any instruction after a FROM
- [Docker docs](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact)

[Build from this commit pulls the new code](https://github.com/coreweave/ml-containers/actions/runs/4186926526/jobs/7256086582#step:8:239)