### PR TITLE
Update to PyTorch 2.0.0 and torchvision 0.15.1

### DIFF
--- a/.github/workflows/torch-base.yml
+++ b/.github/workflows/torch-base.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         cuda: [12.0.1, 11.8.0]
         include:
-          - torch: 2.0.0-rc1
-            vision: 0.15.0-rc1
+          - torch: 2.0.0
+            vision: 0.15.1
 
     uses: ./.github/workflows/torch.yml
     with:

--- a/.github/workflows/torch-nccl.yml
+++ b/.github/workflows/torch-nccl.yml
@@ -20,8 +20,8 @@ jobs:
             nccl: 2.16.2-1
             nccl-tests-hash: 5efeee0
         include:
-          - torch: 2.0.0-rc1
-            vision: 0.15.0-rc1
+          - torch: 2.0.0
+            vision: 0.15.1
 
     uses: ./.github/workflows/torch.yml
     with:

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -2,10 +2,10 @@
 ARG BUILDER_BASE_IMAGE="nvidia/cuda:12.0.1-devel-ubuntu20.04"
 ARG FINAL_BASE_IMAGE="nvidia/cuda:12.0.1-base-ubuntu20.04"
 
-ARG BUILD_TORCH_VERSION="2.0.0-rc1"
-ARG BUILD_TORCH_VISION_VERSION="0.15.0-rc1"
+ARG BUILD_TORCH_VERSION="2.0.0"
+ARG BUILD_TORCH_VISION_VERSION="0.15.1"
 ARG BUILD_TORCH_CUDA_ARCH_LIST="6.0 6.1 6.2 7.0 7.2 7.5 8.0 8.6 8.9 9.0+PTX"
-# 8.7 is not supported until PyTorch 2.0.0-rc2
+# 8.7 is supported in the PyTorch master branch, but not 2.0.0
 
 # Clone PyTorch repositories independently from all other build steps
 # for cache-friendliness and parallelization


### PR DESCRIPTION
[PyTorch 2.0](https://github.com/pytorch/pytorch/releases/tag/v2.0.0) and [torchvision 0.15](https://github.com/pytorch/vision/releases/tag/v0.15.1) officially released about 7 hours ago.

We already had builds available for the development versions, PyTorch 2.0.0-rc1 and torchvision 0.15.0-rc1, so the template for the build itself needs no changes.