### PR TITLE
feat(torch): Add torchaudio, cuDNN support for NCCL builds, and PNG/JPEG support for torchvision

### DIFF
--- a/.github/workflows/torch-base.yml
+++ b/.github/workflows/torch-base.yml
@@ -16,11 +16,13 @@ jobs:
         include:
           - torch: 2.0.0
             vision: 0.15.1
+            audio: 2.0.1
 
     uses: ./.github/workflows/torch.yml
     with:
-      tag: ${{ format('base-cuda{0}-torch{1}-vision{2}', matrix.cuda, matrix.torch, matrix.vision) }}
+      tag: ${{ format('base-cuda{0}-torch{1}-vision{2}-audio{3}', matrix.cuda, matrix.torch, matrix.vision, matrix.audio) }}
       builder-base-image: nvidia/cuda:${{ matrix.cuda }}-devel-ubuntu20.04
       base-image: nvidia/cuda:${{ matrix.cuda }}-base-ubuntu20.04
       torch-version: ${{ matrix.torch }}
       torchvision-version: ${{ matrix.vision }}
+      torchaudio-version: ${{ matrix.audio }}

--- a/.github/workflows/torch-nccl.yml
+++ b/.github/workflows/torch-nccl.yml
@@ -15,18 +15,20 @@ jobs:
         image:
           - cuda: 12.0.1
             nccl: 2.17.1-1
-            nccl-tests-hash: 5efeee0
+            nccl-tests-hash: 1bac5e9
           - cuda: 11.8.0
             nccl: 2.16.2-1
-            nccl-tests-hash: 5efeee0
+            nccl-tests-hash: 1bac5e9
         include:
           - torch: 2.0.0
             vision: 0.15.1
+            audio: 2.0.1
 
     uses: ./.github/workflows/torch.yml
     with:
-      tag: ${{ format('nccl-cuda{0}-nccl{1}-torch{2}-vision{3}', matrix.image.cuda, matrix.image.nccl, matrix.torch, matrix.vision) }}
+      tag: ${{ format('nccl-cuda{0}-nccl{1}-torch{2}-vision{3}-audio{4}', matrix.image.cuda, matrix.image.nccl, matrix.torch, matrix.vision, matrix.audio) }}
       builder-base-image: ghcr.io/coreweave/nccl-tests:${{ matrix.image.cuda }}-cudnn8-devel-ubuntu20.04-nccl${{ matrix.image.nccl }}-${{ matrix.image.nccl-tests-hash }}
       base-image: ghcr.io/coreweave/nccl-tests:${{ matrix.image.cuda }}-cudnn8-devel-ubuntu20.04-nccl${{ matrix.image.nccl }}-${{ matrix.image.nccl-tests-hash }}
       torch-version: ${{ matrix.torch }}
       torchvision-version: ${{ matrix.vision }}
+      torchaudio-version: ${{ matrix.audio }}

--- a/.github/workflows/torch.yml
+++ b/.github/workflows/torch.yml
@@ -16,6 +16,9 @@ on:
       torchvision-version:
         required: true
         type: string
+      torchaudio-version:
+        required: true
+        type: string
       cuda-arch-support:
         required: false
         type: string
@@ -37,6 +40,9 @@ on:
       torchvision-version:
         required: true
         type: string
+      torchaudio-version:
+        required: true
+        type: string
       cuda-arch-support:
         required: false
         type: string
@@ -53,4 +59,5 @@ jobs:
         FINAL_BASE_IMAGE=${{ inputs.base-image }}
         BUILD_TORCH_VERSION=${{ inputs.torch-version }}
         BUILD_TORCH_VISION_VERSION=${{ inputs.torchvision-version }}
+        BUILD_TORCH_AUDIO_VERSION=${{ inputs.torchaudio-version }}
         ${{ inputs.cuda-arch-support && format('BUILD_TORCH_CUDA_ARCH_LIST={0}', inputs.cuda-arch-support) || '' }}

--- a/.github/workflows/torch.yml
+++ b/.github/workflows/torch.yml
@@ -55,6 +55,7 @@ jobs:
       folder: torch
       tag-suffix: ${{ inputs.tag }}
       build-args: |
+        BUILD_CCACHE_SIZE=1Gi
         BUILDER_BASE_IMAGE=${{ inputs.builder-base-image }}
         FINAL_BASE_IMAGE=${{ inputs.base-image }}
         BUILD_TORCH_VERSION=${{ inputs.torch-version }}

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -27,18 +27,26 @@ RUN git clone --recurse-submodules --shallow-submodules -j8 --depth 1 \
 FROM ${BUILDER_BASE_IMAGE} as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
-# ninja-build, gcc-10, g++-10, and lld are optional but improve the build
+# ninja-build, ccache, gcc-10, g++-10, and lld are optional but improve the build
 RUN apt-get -qq update && apt-get -qq install -y \
       libncurses5 python3 python3-pip git apt-utils ssh ca-certificates \
-      python3-distutils python3-numpy build-essential ninja-build \
-      gcc-10 g++-10 lld && \
+      libpng-dev libjpeg-dev pkg-config python3-distutils python3-numpy \
+      build-essential ninja-build ccache gcc-10 g++-10 lld && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
     update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 1 && \
+    ccache -M 5Gi && \
+    ccache -F 0 && \
     pip3 install --no-cache-dir --upgrade pip && \
     apt-get clean
+
+# Build-time environment variables
+ENV CCACHE_DIR=/ccache \
+    CMAKE_C_COMPILER_LAUNCHER=ccache \
+    CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    CMAKE_CUDA_COMPILER_LAUNCHER=ccache
 
 # Add Kitware's apt repository to get a newer version of CMake
 RUN apt-get -qq update && apt-get -qq install -y \
@@ -68,6 +76,14 @@ ARG BUILD_TORCH_VERSION
 ARG BUILD_TORCH_CUDA_ARCH_LIST
 ENV TORCH_VERSION=$BUILD_TORCH_VERSION
 ENV TORCH_CUDA_ARCH_LIST=$BUILD_TORCH_CUDA_ARCH_LIST
+
+# Build tool & library paths, shared for all libraries to be built
+ENV CMAKE_PREFIX_PATH=/usr/bin/ \
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64:/usr/local/lib \
+    CUDA_BIN_PATH=/usr/local/cuda/bin \
+    CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
+    CUDNN_LIB_DIR=/usr/local/cuda/lib64
+
 # If the directory /opt/nccl-tests exists,
 # the base image is assumed to be nccl-tests,
 # so it uses the system's special NCCL and UCC installations for the build.
@@ -82,6 +98,7 @@ ENV TORCH_CUDA_ARCH_LIST=$BUILD_TORCH_CUDA_ARCH_LIST
 # This step is itself cacheable as long as the downloaded files (and ARCH_LIST)
 # remain the same.
 RUN --mount=type=bind,from=pytorch-downloader,source=/git/pytorch,target=pytorch/,rw \
+    --mount=type=cache,target=/ccache \
     cd pytorch && \
     mkdir build && \
     ln -s /usr/bin/cc build/cc && \
@@ -89,6 +106,7 @@ RUN --mount=type=bind,from=pytorch-downloader,source=/git/pytorch,target=pytorch
     { if [ -d /opt/nccl-tests ]; then \
       export \
         USE_DISTRIBUTED=1 \
+        USE_CUDNN=1 \
         USE_NCCL=1 USE_SYSTEM_NCCL=1 \
         UCC_HOME=${HPCX_UCC_DIR} UCX_HOME=${HPCX_UCX_DIR} \
         USE_NCCL_WITH_UCC=1 \
@@ -96,11 +114,6 @@ RUN --mount=type=bind,from=pytorch-downloader,source=/git/pytorch,target=pytorch
     USE_OPENCV=1 \
     BUILD_TORCH=ON \
     BUILD_TEST=0 \
-    CMAKE_PREFIX_PATH="/usr/bin/" \
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib \
-    CUDA_BIN_PATH=/usr/local/cuda/bin \
-    CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
-    CUDNN_LIB_DIR=/usr/local/cuda/lib64 \
     CUDA_HOST_COMPILER=cc \
     USE_CUDA=1 \
     USE_NNPACK=1 \
@@ -110,7 +123,6 @@ RUN --mount=type=bind,from=pytorch-downloader,source=/git/pytorch,target=pytorch
     USE_MKL=OFF \
     PYTORCH_BUILD_VERSION="${TORCH_VERSION}" \
     PYTORCH_BUILD_NUMBER=0 \
-    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     python3 setup.py bdist_wheel --dist-dir ../dist
 RUN pip3 install --no-cache-dir --upgrade dist/torch*.whl
@@ -129,6 +141,7 @@ RUN --mount=type=bind,from=torchvision-downloader,source=/git/vision,target=visi
     { if [ -d /opt/nccl-tests ]; then \
       export \
         USE_DISTRIBUTED=1 \
+        USE_CUDNN=1 \
         USE_NCCL=1 USE_SYSTEM_NCCL=1 \
         UCC_HOME=${HPCX_UCC_DIR} UCX_HOME=${HPCX_UCX_DIR} \
         USE_NCCL_WITH_UCC=1 \
@@ -136,20 +149,15 @@ RUN --mount=type=bind,from=torchvision-downloader,source=/git/vision,target=visi
     USE_OPENCV=1 \
     BUILD_TORCH=ON \
     BUILD_TEST=0 \
-    CMAKE_PREFIX_PATH="/usr/bin/" \
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib \
-    CUDA_BIN_PATH=/usr/local/cuda/bin \
-    CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
-    CUDNN_LIB_DIR=/usr/local/cuda/lib64 \
     CUDA_HOST_COMPILER=cc \
     USE_CUDA=1 \
+    FORCE_CUDA=1 \
     USE_NNPACK=1 \
     CC=cc \
     CXX=c++ \
     USE_EIGEN_FOR_BLAS=ON \
     USE_MKL=OFF \
     BUILD_VERSION="${TORCH_VISION_VERSION}" \
-    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     python3 setup.py bdist_wheel --dist-dir ../dist
 

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -4,6 +4,7 @@ ARG FINAL_BASE_IMAGE="nvidia/cuda:12.0.1-base-ubuntu20.04"
 
 ARG BUILD_TORCH_VERSION="2.0.0"
 ARG BUILD_TORCH_VISION_VERSION="0.15.1"
+ARG BUILD_TORCH_AUDIO_VERSION="2.0.1"
 ARG BUILD_TORCH_CUDA_ARCH_LIST="6.0 6.1 6.2 7.0 7.2 7.5 8.0 8.6 8.9 9.0+PTX"
 # 8.7 is supported in the PyTorch master branch, but not 2.0.0
 
@@ -22,6 +23,14 @@ ARG BUILD_TORCH_VISION_VERSION
 RUN git clone --recurse-submodules --shallow-submodules -j8 --depth 1 \
       https://github.com/pytorch/vision -b v${BUILD_TORCH_VISION_VERSION} && \
     rm -rf vision/.git
+
+FROM alpine/git:2.36.3 as torchaudio-downloader
+WORKDIR /git
+ARG BUILD_TORCH_AUDIO_VERSION
+RUN git clone --recurse-submodules --shallow-submodules -j8 --depth 1 \
+      https://github.com/pytorch/audio -b v${BUILD_TORCH_AUDIO_VERSION}
+# The torchaudio build requires that this directory remain a full git repository,
+# so no rm -rf audio/.git is done for this one.
 
 ## Build PyTorch on a builder image.
 FROM ${BUILDER_BASE_IMAGE} as builder
@@ -161,6 +170,40 @@ RUN --mount=type=bind,from=torchvision-downloader,source=/git/vision,target=visi
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     python3 setup.py bdist_wheel --dist-dir ../dist
 
+## Build torchaudio
+ARG BUILD_TORCH_AUDIO_VERSION
+ENV TORCH_AUDIO_VERSION=$BUILD_TORCH_AUDIO_VERSION
+RUN pip3 install --no-cache-dir --upgrade \
+    matplotlib numpy typing_extensions requests pillow
+
+RUN --mount=type=bind,from=torchaudio-downloader,source=/git/audio,target=audio/,rw \
+    cd audio && \
+    mkdir build && \
+    ln -s /usr/bin/cc build/cc && \
+    ln -s /usr/bin/c++ build/c++ && \
+    { if [ -d /opt/nccl-tests ]; then \
+      export \
+        USE_DISTRIBUTED=1 \
+        USE_CUDNN=1 \
+        USE_NCCL=1 USE_SYSTEM_NCCL=1 \
+        UCC_HOME=${HPCX_UCC_DIR} UCX_HOME=${HPCX_UCX_DIR} \
+        USE_NCCL_WITH_UCC=1 \
+        USE_UCC=1 USE_SYSTEM_UCC=1; fi; } && \
+    USE_OPENCV=1 \
+    BUILD_TORCH=ON \
+    BUILD_TEST=0 \
+    CUDA_HOST_COMPILER=cc \
+    USE_CUDA=1 \
+    FORCE_CUDA=1 \
+    USE_NNPACK=1 \
+    CC=cc \
+    CXX=c++ \
+    USE_EIGEN_FOR_BLAS=ON \
+    USE_MKL=OFF \
+    BUILD_VERSION="${TORCH_AUDIO_VERSION}" \
+    TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
+    python3 setup.py bdist_wheel --dist-dir ../dist
+
 
 ## Build the final torch image.
 FROM ${FINAL_BASE_IMAGE}
@@ -186,9 +229,11 @@ RUN if [ -d /opt/nccl-tests ]; then \
 
 ARG BUILD_TORCH_VERSION
 ARG BUILD_TORCH_VISION_VERSION
+ARG BUILD_TORCH_AUDIO_VERSION
 ARG BUILD_TORCH_CUDA_ARCH_LIST
 ENV TORCH_VERSION=$BUILD_TORCH_VERSION
 ENV TORCH_VISION_VERSION=$BUILD_TORCH_VISION_VERSION
+ENV TORCH_AUDIO_VERSION=$BUILD_TORCH_AUDIO_VERSION
 ENV TORCH_CUDA_ARCH_LIST=$BUILD_TORCH_CUDA_ARCH_LIST
 
 # - libnvjitlink-X-Y only exists for CUDA versions >= 12-0.

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -36,6 +36,8 @@ RUN git clone --recurse-submodules --shallow-submodules -j8 --depth 1 \
 FROM ${BUILDER_BASE_IMAGE} as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG BUILD_CCACHE_SIZE="1Gi"
+
 # ninja-build, ccache, gcc-10, g++-10, and lld are optional but improve the build
 RUN apt-get -qq update && apt-get -qq install -y \
       libncurses5 python3 python3-pip git apt-utils ssh ca-certificates \
@@ -46,7 +48,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
     update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 1 && \
-    ccache -M 5Gi && \
+    ccache -M "${BUILD_CCACHE_SIZE}" && \
     ccache -F 0 && \
     pip3 install --no-cache-dir --upgrade pip && \
     apt-get clean


### PR DESCRIPTION
# New Libraries
- This PR adds the `torchaudio` PyTorch extension library to the `torch` container build process.
- The other main PyTorch extension library, `torchvision`, was already included, but its build has been updated as well to include proper PNG/JPEG file support.
- Since the `nccl-tests` base containers now include cuDNN, `torch:nccl` builds now explicitly compile PyTorch and its extensions with cuDNN support enabled.
- A configurable compiler cache was also added in the build stage, to make the builds take slightly less of forever.
  - A *15* GiB cache cuts around an hour off of build times in my testing. PyTorch recommends 25 GiB.
  - It isn't known how well the GitHub Actions runner will handle it (if at all), so it's being added here starting at 1 GiB.
    - This is adjustable with a `docker build` argument, so it can be increased or decreased fairly easily later on.