### PR TITLE
feat(llm-finetuner): Migrate LLM finetuner image from `kubernetes-cloud`

### DIFF
--- a/.github/workflows/llm-finetuner.yml
+++ b/.github/workflows/llm-finetuner.yml
@@ -1,0 +1,15 @@
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit to build'
+        required: true
+
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with: 
+      image-name: llm-finetuner
+      folder: llm-finetuner
+      build-args: "COMMIT=${{ inputs.commit }}"

--- a/llm-finetuner/Dockerfile
+++ b/llm-finetuner/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1.2
+
+ARG BASE_IMAGE=ghcr.io/coreweave/ml-containers/torch:afecfe9-base-cuda11.8.0-torch2.0.0-vision0.15.1
+
+FROM alpine/git:2.36.3 as downloader
+WORKDIR /git
+
+# Note: avoid using a branch name as the commit to prevent erroneous caching.
+ARG COMMIT
+
+# Download only the required files from the repository
+RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
+      https://github.com/coreweave/kubernetes-cloud && \
+    cd kubernetes-cloud && \
+    git sparse-checkout init && \
+    git config --worktree core.sparseCheckoutCone false && \
+    git config --worktree advice.detachedHead false && \
+    git sparse-checkout set /finetuner-workflow/finetuner && \
+    git checkout "${COMMIT}" && \
+    rm -rf .git && \
+    [ -d finetuner-workflow/finetuner ] && \
+    ln -s $(realpath finetuner-workflow/finetuner) /src
+
+WORKDIR /src
+
+# Dependencies requiring NVCC are built ahead of time in a separate stage
+# so that the ~2 GiB dev library installations don't have to be included
+# in the final finetuner image.
+FROM ${BASE_IMAGE} as builder
+RUN apt-get install -y --no-install-recommends \
+        cuda-nvcc-11-8 cuda-nvml-dev-11-8 libcurand-dev-11-8 \
+        libcublas-dev-11-8 libcusparse-dev-11-8 \
+        libcusolver-dev-11-8 cuda-nvprof-11-8 \
+        cuda-profiler-api-11-8 \
+        ninja-build \
+        # gcc-10/g++-10/lld do not need to be installed here, but they improve the build.
+        # gfortran-10 is just for compiler_wrapper.f95.
+        gcc-10 g++-10 gfortran-10 lld && \
+    apt-get clean && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
+    update-alternatives --install \
+      /usr/bin/gfortran gfortran /usr/bin/gfortran-10 10 && \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld 1
+
+RUN mkdir /wheels /build
+WORKDIR /build
+COPY compiler_wrapper.f95 .
+COPY --from=downloader /src/requirements-precompilable.txt .
+RUN gfortran -O3 ./compiler_wrapper.f95 -o ./compiler && \
+    python3 -m pip install -U --no-cache-dir \
+      packaging setuptools wheel pip && \
+    # Only DS_BUILT_UTILS and DS_BUILD_CPU_ADAM are necessary for the finetuner
+    # See: https://www.deepspeed.ai/tutorials/advanced-install
+    DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAM=1 \
+      # DeepSpeed forces -march=native into the compiler options,
+      # making the result dependent on the processor architecture
+      # used on the builder machine.
+      # The compiler wrapper normalizes -march=native to -march=skylake
+      # along with a couple other transformations before invoking GCC.
+      CC=$(realpath -e ./compiler) \
+      python3 -m pip wheel -w /wheels \
+      --no-cache-dir --no-build-isolation --no-deps \
+      -r requirements-precompilable.txt && \
+    rm ./*
+
+WORKDIR /wheels
+
+FROM ${BASE_IMAGE}
+RUN mkdir /app
+WORKDIR /app
+RUN --mount=type=bind,from=builder,source=/wheels,target=. \
+    pip3 install --no-cache-dir ./*.whl
+COPY --from=downloader /src/requirements.txt .
+COPY --from=downloader /src/requirements-precompilable.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+COPY --from=downloader /src/ds_config.json .
+COPY --from=downloader /src/finetuner.py .
+COPY --from=downloader /src/evaluator.py .
+COPY --from=downloader /src/inference.py .
+COPY --from=downloader /src/utils.py .
+CMD [ "/usr/bin/python3", "finetuner.py" ]

--- a/llm-finetuner/compiler_wrapper.f95
+++ b/llm-finetuner/compiler_wrapper.f95
@@ -1,0 +1,76 @@
+PROGRAM compiler_wrapper
+    ! Wraps GCC invocations,
+    ! replacing -D__AVX512__ and -D__SCALAR__ preprocessor definitions
+    ! with -D__AVX256__, and -march=native with -march=skylake,
+    ! for better reproducibility and compatibility.
+    IMPLICIT NONE
+    INTEGER :: i, exitcode = 0, full_length = 0, truncated = 0
+    CHARACTER(len=:), ALLOCATABLE :: arg, command
+    ALLOCATE(CHARACTER(len=128) :: arg)
+    command = "gcc"
+
+    DO i = 1, COMMAND_ARGUMENT_COUNT()
+        DO
+            CALL GET_COMMAND_ARGUMENT(i, arg, full_length, truncated)
+            IF (truncated == 0) THEN
+                EXIT
+            ELSE IF (truncated == -1) THEN
+                DEALLOCATE(arg)
+                ALLOCATE(CHARACTER(len=full_length) :: arg)
+            ELSE
+                CALL EXIT(95)
+            END IF
+        END DO
+        IF (arg == "-march=native") THEN
+            command = command // " '-march=skylake'"
+        ELSE IF (arg == "-D__AVX512__" .OR. arg == "-D__SCALAR__") THEN
+            command = command // " '-D__AVX256__'"
+        ELSE
+            command = command // shell_escaped(arg)
+        END IF
+    END DO
+    CALL SYSTEM(command, exitcode)
+    IF (exitcode > 255) THEN
+        exitcode = MAX(IAND(exitcode, 255), 1)
+    END IF
+    CALL EXIT(exitcode)
+
+
+    CONTAINS
+        FUNCTION shell_escaped(str) RESULT(out)
+            ! Turns [str] into [ 'str'] and replaces all
+            ! internal ['] characters with ['"'"']
+            IMPLICIT NONE
+            CHARACTER(len=*), INTENT(IN) :: str
+            CHARACTER(len=:), ALLOCATABLE :: out
+            INTEGER :: old_i, out_i, old_len, out_len
+
+            old_len = LEN_TRIM(str)
+            ! Figure out the new length to allocate by scanning `str`.
+            ! This always needs to add at least [ '] at the beginning
+            ! and ['] at the end, so the length increases by at least 3.
+            out_len = old_len + 3
+            DO old_i = 1, old_len
+                IF (str(old_i:old_i) == "'") THEN
+                    out_len = out_len + 4
+                END IF
+            END DO
+            ALLOCATE(CHARACTER(len=out_len) :: out)
+
+            ! Copy over the string, performing necessary escapes.
+            out(1:2) = " '"
+            out_i = 3
+            DO old_i = 1, old_len
+                IF (str(old_i:old_i) == "'") THEN
+                    ! Escape internal single-quotes
+                    out(out_i:out_i + 4) = '''"''"'''
+                    out_i = out_i + 5
+                ELSE
+                    ! No escaping needed
+                    out(out_i:out_i) = str(old_i:old_i)
+                    out_i = out_i + 1
+                END IF
+            END DO
+            out(out_i:out_i) = "'"
+        END FUNCTION
+END PROGRAM


### PR DESCRIPTION
# LLM Finetuner Container

This re-homes the container for [`coreweave/kubernetes-cloud`](https://github.com/coreweave/kubernetes-cloud)'s LLM finetuner by copying over its [`Dockerfile`](https://github.com/coreweave/kubernetes-cloud/blob/6c100190564a05abed79503171638e81e18bdc53/finetuner-workflow/finetuner/Dockerfile) and [compiler wrapper](https://github.com/coreweave/kubernetes-cloud/blob/6c100190564a05abed79503171638e81e18bdc53/finetuner-workflow/finetuner/compiler_wrapper.f95) as they appeared in commit [6c10019 under the directory `finetuner-workflow/finetuner`](https://github.com/coreweave/kubernetes-cloud/tree/6c100190564a05abed79503171638e81e18bdc53/finetuner-workflow/finetuner) in that repository, with some updates for cross-repository downloading added to the build.

## Neat Things About the Build

The [`coreweave/kubernetes-cloud`](https://github.com/coreweave/kubernetes-cloud) repository is absolutely massive. At the time of writing, `git clone https://github.com/coreweave/kubernetes-cloud` thwacks you with a ***607 MiB*** download, primarily comprising nearly 400 MiB of image files under `/docs` and an almost 200 MiB `.git` directory.
This is a bit over-the-top to download just a handful of files, so this container's build is configured to do *sparse checkouts* that reduce the download size ***1000x***, to a bit under 600 KiB, which is further reduced to just a few dozen kilobytes by deleting the `.git` directory at the end of the download step.

It's a nice improvement that could be integrated into this repository's [`sd-finetuner` container build](https://github.com/coreweave/ml-containers/blob/bb02beee4b24ba1d3641bf2aeae9da3bd264d0d6/sd-finetuner/Dockerfile) as well, which currently leaves that full 600+ MiB repository in its final image.

## Weird Things About the Build

### Building from a Branch

Branch names *can* but *probably should not* be used as commit identifiers for these builds, because Docker may cache the download by the branch's name, which isn't good if the branch has received updates and is expected to be re-downloaded in an updated state. The hash of the latest commit should be used instead.

### Coupling

There is currently no default commit defined for the build, and accordingly, no rule to automatically rebuild the image on updates pushed here. The list of files copied during the build process is very specific and doesn't adapt very well between versions of the source.
This could be alleviated a bit by copying over the entire `finetuner-workflow/finetuner` directory into the final image, but I still see this potentially becoming very annoying to manage between many possible concurrent branches in `kubernetes-cloud` that could each require distinct build instructions over here, and tracking down corresponding historical changes across two the repositories seems painful.

To make that better, we could work on making the build instructions very generic, like including a version-controlled `install.sh` (or something) over in `kubernetes-cloud` and running most of the work in there. Alternatively, the LLM finetuner could have its own repository with this container published in it.

**Alternatively,** this entire Dockerfile could be left in `kubernetes-cloud`, versioned with the rest of the source, and we could dynamically download it and build it here in `ml-containers` from any given commit *entirely through a workflow*, without any corresponding directory here (or maybe one with only a `README`). This would cut down on the headache of managing the source in multiple disconnected places while still keeping the container in the central `ml-containers` repository.

I'd welcome some thoughts on this point.