### PR TITLE
build(torch)!: Drop arches 6.0, 6.1, 6.2, & 7.2 as compilation targets

### DIFF
--- a/.github/workflows/torch.yml
+++ b/.github/workflows/torch.yml
@@ -22,6 +22,7 @@ on:
       cuda-arch-support:
         required: false
         type: string
+        default: "7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 
   workflow_dispatch:
     inputs:
@@ -46,6 +47,7 @@ on:
       cuda-arch-support:
         required: false
         type: string
+        default: "7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 
 jobs:
   build:


### PR DESCRIPTION
# Slimmer PyTorch Builds

Compilation target architectures 6.0, 6.1, 6.2, & 7.2 do not correspond to any GPUs currently offered by CoreWeave, and bloat the resulting builds, so they are removed as CI defaults. They can still be compiled by manually invoking a Dockerfile build.

The [list of GPU architectures currently offered by CoreWeave](https://docs.coreweave.com/coreweave-kubernetes/node-types#component-availability) are:

| GPU                 | Generation | Architecture Code | 
|---------------------|------------|-------------------| 
| `H100_NVLINK_80GB`  | Hopper     | `sm_90`           | 
| `H100_PCIE`         | Hopper     | `sm_90`           | 
| `A100_NVLINK_80GB`  | Ampere     | `sm_80`           | 
| `A100_NVLINK`       | Ampere     | `sm_80`           | 
| `A100_PCIE_40GB`    | Ampere     | `sm_80`           | 
| `A100_PCIE_80GB`    | Ampere     | `sm_80`           | 
| `A40`               | Ampere     | `sm_86`           | 
| `RTX_A6000`         | Ampere     | `sm_86`           | 
| `RTX_A5000`         | Ampere     | `sm_86`           | 
| `RTX_A4000`         | Ampere     | `sm_86`           | 
| `Tesla_V100_NVLINK` | Volta      | `sm_70`           | 
| `Quadro_RTX_5000`   | Turing     | `sm_75`           | 
| `Quadro_RTX_4000`   | Turing     | `sm_75`           | 