### PR TITLE
build(torch): Add CUDA 12.1 builds

### DIFF
--- a/.github/workflows/torch-base.yml
+++ b/.github/workflows/torch-base.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        cuda: [12.1.1,  12.0.1, 11.8.0]
+        cuda: [12.1.1, 12.0.1, 11.8.0]
         include:
           - torch: 2.0.1
             vision: 0.15.2

--- a/.github/workflows/torch-base.yml
+++ b/.github/workflows/torch-base.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        cuda: [12.0.1, 11.8.0]
+        cuda: [12.1.1,  12.0.1, 11.8.0]
         include:
           - torch: 2.0.1
             vision: 0.15.2

--- a/.github/workflows/torch-nccl.yml
+++ b/.github/workflows/torch-nccl.yml
@@ -13,6 +13,9 @@ jobs:
     strategy:
       matrix:
         image:
+          - cuda: 12.1.1
+            nccl: 2.18.1-1
+            nccl-tests-hash: e90a40f
           - cuda: 12.0.1
             nccl: 2.18.1-1
             nccl-tests-hash: e90a40f


### PR DESCRIPTION
Update to add CUDA 12.1.1 builds for both `torch` containers. They are added in addition to the 12.0.1 and 11.8.0 builds, and do not replace either of them.