### PR TITLE
fix(torch-extras): Use `rw` bind mount when building `flash-attn`

### DIFF
--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -104,7 +104,7 @@ WORKDIR /wheels
 FROM builder-base as flash-attn-builder
 ARG FLASH_ATTN_VERSION
 
-RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,target=flash-attention/ \
+RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,target=flash-attention/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \


### PR DESCRIPTION
This change fixes a bug that prevented the `torch-extras` Dockerfile from being able to compile `flash-attn`.
Its git source directory was mounted read-only because of a missing `rw` flag on its bind mount, so it couldn't write build files.