### PR TITLE
build(torch-extras): Extract `torch-extras` workflow to be dispatchable

### DIFF
--- a/.github/workflows/torch-extras.yml
+++ b/.github/workflows/torch-extras.yml
@@ -1,0 +1,29 @@
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      base-image:
+        required: true
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+      base-image:
+        required: true
+        type: string
+
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      image-name: torch-extras
+      folder: torch-extras
+      tag-suffix: ${{ inputs.tag }}
+      build-args: |
+        BASE_IMAGE=${{ inputs.base-image }}

--- a/.github/workflows/torch.yml
+++ b/.github/workflows/torch.yml
@@ -75,10 +75,7 @@ jobs:
   build-extras:
     if: inputs.build-extras
     needs: build
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/torch-extras.yml
     with:
-      image-name: torch-extras
-      folder: torch-extras
-      tag-suffix: ${{ inputs.tag }}
-      build-args: |
-        BASE_IMAGE=${{ needs.build.outputs.tags }}
+      tag: ${{ inputs.tag }}
+      base-image: ${{ needs.build.outputs.tags }}

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -191,4 +191,3 @@ RUN --mount=type=bind,from=flash-attn-builder,source=/wheels,target=/tmp/wheels 
     python3 -m pip install --no-cache-dir /tmp/wheels/*.whl
 RUN --mount=type=bind,from=apex-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir /tmp/wheels/*.whl
-RUN rm -r /tmp/wheels


### PR DESCRIPTION
This change extracts `.github/workflows/torch-extras.yml` from `.github/workflows/torch.yml` to make it independently dispatchable.

Since `torch-extras.yml` cannot run on each push to `torch-extras/Dockerfile`, as it has no default base image to build from, a dispatchable workflow is currently necessary to build new `torch-extras` containers when a file in `torch-extras/` has been modified but nothing has changed for the base `torch` files.

This PR also fixes a bug in `torch-extras/Dockerfile` that prevented it from building correctly in daf476342951c6c19e8eace6dd755d167573fa42.