### PR TITLE
fix(torch-extras): Add `-prune` to `find` & `rm -r` Apex downloader step

### DIFF
--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
     cd apex && \
     git checkout "${APEX_COMMIT}" && \
     git submodule update --init --recursive --depth 1 --jobs 8 && \
-    find -type d -name docs -exec rm -r '{}' ';' 2> /dev/null
+    find -type d -name docs -prune -exec rm -r '{}' ';'
 
 
 # Dependencies requiring NVCC are built ahead of time in a separate stage


### PR DESCRIPTION
# `find`, `-prune`, and `rm -r`
This change fixes a bug causing the `apex-downloader` step to fail while deleting unnecessary files post-downloading.

Without the `-prune` flag, the `find` call in use attempts to `rm -r` directories within already-deleted subtrees and exits with an error code despite producing correct results. With the `-prune` flag, acting on a directory instead removes its children from further `find` processing, which is correct for already-recursive commands such as `rm -r`.