### PR TITLE
build(torch): Update base images for NCCL builds, now with NCCL v2.18.3

### DIFF
--- a/.github/workflows/torch-nccl.yml
+++ b/.github/workflows/torch-nccl.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         image:
           - cuda: 12.1.1
-            nccl: 2.18.1-1
-            nccl-tests-hash: e90a40f
+            nccl: 2.18.3-1
+            nccl-tests-hash: 471f0db
           - cuda: 12.0.1
-            nccl: 2.18.1-1
-            nccl-tests-hash: e90a40f
+            nccl: 2.18.3-1
+            nccl-tests-hash: 471f0db
           - cuda: 11.8.0
             nccl: 2.16.2-1
-            nccl-tests-hash: e90a40f
+            nccl-tests-hash: 471f0db
         include:
           - torch: 2.0.1
             vision: 0.15.2

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -9,8 +9,8 @@ FROM alpine/git:2.36.3 as flash-attn-downloader
 WORKDIR /git
 ARG FLASH_ATTN_VERSION
 RUN git clone --recurse-submodules --shallow-submodules -j8 --depth 1 \
-      https://github.com/HazyResearch/flash-attention -b v${FLASH_ATTN_VERSION} && \
-    rm -rf flash-attention/.git
+      --filter=blob:none --also-filter-submodules \
+      https://github.com/HazyResearch/flash-attention -b v${FLASH_ATTN_VERSION}
 
 FROM alpine/git:2.36.3 as apex-downloader
 WORKDIR /git
@@ -43,7 +43,6 @@ RUN export \
       cuda-profiler-api-${CUDA_PACKAGE_VERSION} \
       libaio-dev \
       ninja-build \
-      parallel \
       # gcc-10/g++-10/lld do not need to be installed here, but they improve the build.
       # gfortran-10 is just for compiler_wrapper.f95.
       gcc-10 g++-10 gfortran-10 lld && \
@@ -121,16 +120,26 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS=$(($(./effective_cpu_count.sh) + 2)) && \
+    export MAX_JOBS=$(($(./effective_cpu_count.sh) / 4)) && \
+    export MAX_JOBS=$((MAX_JOBS == 0 ? 1 : MAX_JOBS)) && \
+    export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     cd flash-attention && \
-    parallel 'cd {} && python3 setup.py bdist_wheel --dist-dir /wheels' ::: \
-      . \
-      csrc/ft_attention \
-      csrc/fused_dense_lib \
-      csrc/fused_softmax \
-      csrc/layer_norm \
-      csrc/rotary \
-      csrc/xentropy
+    ( \
+      for EXT_DIR in $(realpath -s -e \
+        . \
+        csrc/ft_attention \
+        csrc/fused_dense_lib \
+        csrc/fused_softmax \
+        csrc/layer_norm \
+        csrc/rotary \
+        csrc/xentropy); \
+      do \
+          cd $EXT_DIR && \
+          python3 setup.py bdist_wheel --dist-dir /wheels && \
+          cd - || \
+          exit 1; \
+      done; \
+    )
 
 WORKDIR /wheels
 

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -19,7 +19,8 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
       https://github.com/NVIDIA/apex && \
     cd apex && \
     git checkout "${APEX_COMMIT}" && \
-    git submodule update --init --recursive --depth 1 --jobs 8 && \
+    git submodule update --init --recursive --jobs 8 \
+      --depth 1 --filter=blob:none && \
     find -type d -name docs -prune -exec rm -r '{}' ';'
 
 


### PR DESCRIPTION
# PyTorch with NCCL v2.18.3

This change uses the new NCCL v2.18.3 builds from [coreweave/nccl-tests PR 23](https://github.com/coreweave/nccl-tests/pull/23) in this repository's CUDA 12.0 & 12.1 builds of `torch:nccl`, updating from NCCL version 2.18.1.