### PR TITLE
build(torch): Build `nccl` images from bases with HPC-X v2.16

### DIFF
--- a/.github/workflows/torch-nccl.yml
+++ b/.github/workflows/torch-nccl.yml
@@ -15,13 +15,13 @@ jobs:
         image:
           - cuda: 12.1.1
             nccl: 2.18.3-1
-            nccl-tests-hash: 471f0db
+            nccl-tests-hash: 253a5b1
           - cuda: 12.0.1
             nccl: 2.18.3-1
-            nccl-tests-hash: 471f0db
+            nccl-tests-hash: 253a5b1
           - cuda: 11.8.0
             nccl: 2.16.2-1
-            nccl-tests-hash: 471f0db
+            nccl-tests-hash: 253a5b1
         include:
           - torch: 2.0.1
             vision: 0.15.2


### PR DESCRIPTION
# `torch:nccl` with HPC-X v2.16

This change updates the base `nccl-tests` images used to build `torch:nccl` to versions featuring HPC-X v2.16, as introduced in coreweave/nccl-tests#25.