### PR TITLE
fix(torch-extras): Build `torch-extras` off of the most recent `torch` images

### DIFF
--- a/.github/workflows/torch-extras.yml
+++ b/.github/workflows/torch-extras.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           RELEASES="$( \
             /bin/curl -f -s --oauth2-bearer "$(echo "$BEARER_TOKEN" | base64 -w 0)" \
-              https://ghcr.io/v2/coreweave/ml-containers%2Ftorch/tags/list \
+              'https://ghcr.io/v2/coreweave/ml-containers%2Ftorch/tags/list?n=100000' \
             | jq -r '.["tags"][]' \
             | grep -E '^[0-9a-f]{7}-(base|nccl)-' \
           )" && \


### PR DESCRIPTION
# `torch-extras` / `torch` mismatch

This change fixes a bug that was causing `torch-extras` to sometimes build off of outdated `torch` images in our CI pipeline.

The bug was because `ghcr.io`'s implementation of the [`/v2/<package>/tags/list` registry endpoint](https://docs.docker.com/registry/spec/api/#listing-image-tags), which we use to determine the latest torch image to build from, automatically switches to paginated results unless otherwise requested once the result set is large enough, instead of only switching when requested. Since the results are ordered chronologically (oldest to newest), this means the last result—which would normally be the newest `torch` image—was not actually the newest `torch` image.

A more stable fix for this in the future would be to properly parse the paginated results, but since it accepts `n=100000` (asking for a page size of 100000) without any warnings, this seems to work fine too.