### PR TITLE
build(torch-extras): Fix `xformers` & Limit Concurrency

### DIFF
--- a/.github/workflows/torch-extras.yml
+++ b/.github/workflows/torch-extras.yml
@@ -136,7 +136,7 @@ jobs:
     if: inputs.skip-bases-check
     strategy:
       matrix:
-        flash-attn: [ 2.0.2, 1.0.9 ]
+        flash-attn: [ 2.3.6 ]
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
@@ -153,7 +153,7 @@ jobs:
     if: needs.get-required-bases.outputs.bases-list && needs.get-required-bases.outputs.bases-list != '[]'
     strategy:
       matrix:
-        flash-attn: [ 2.0.2, 1.0.9 ]
+        flash-attn: [ 2.3.6 ]
         bases: ${{ fromJSON(needs.get-required-bases.outputs.bases-list) }}
     uses: ./.github/workflows/build.yml
     secrets: inherit

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -82,6 +82,7 @@ COPY compiler_wrapper.f95 .
 RUN gfortran -O3 ./compiler_wrapper.f95 -o ./compiler && rm ./compiler_wrapper.f95
 
 COPY --chmod=755 effective_cpu_count.sh .
+COPY --chmod=755 scale.sh .
 
 
 FROM builder-base as deepspeed-builder
@@ -127,7 +128,7 @@ RUN python3 -m pip install -U --no-cache-dir \
       do if [[ -z ${!VAR} ]]; then unset ${VAR}; fi; done; \
     } && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS=$(($(./effective_cpu_count.sh) + 2)) \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 48)" \
       python3 -m pip wheel -w /wheels \
       --no-cache-dir --no-build-isolation --no-deps \
       deepspeed==${DEEPSPEED_VERSION} && \
@@ -143,8 +144,7 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS=$(($(./effective_cpu_count.sh) / 4)) && \
-    export MAX_JOBS=$((MAX_JOBS == 0 ? 1 : MAX_JOBS)) && \
+    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 24)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     cd flash-attention && \
     ( \
@@ -180,7 +180,7 @@ RUN --mount=type=bind,from=apex-downloader,source=/git/apex,target=apex/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS=$(($(./effective_cpu_count.sh) + 2)) && \
+    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 48)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     printf -- '--config-settings="--build-option=%s" ' $( \
       echo \
@@ -223,7 +223,7 @@ ARG XFORMERS_VERSION
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS=$(($(./effective_cpu_count.sh) / 2 + 1)) \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 24)" \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE
 ARG DEEPSPEED_VERSION="0.10.3"
 ARG FLASH_ATTN_VERSION="2.0.2"
 ARG APEX_COMMIT="38a12698bc3cc95987bca270bcd6d025bb0be346"
-ARG XFORMERS_VERSION="0.0.22.post7"
+ARG XFORMERS_VERSION="0.0.22"
 
 FROM alpine/git:2.36.3 as flash-attn-downloader
 WORKDIR /git
@@ -224,10 +224,12 @@ RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
       MAX_JOBS=1 \
+      PYTHONUNBUFFERED=1 \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \
-      xformers==${XFORMERS_VERSION}
+      xformers==${XFORMERS_VERSION} | \
+    grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores'
 
 
 FROM ${BASE_IMAGE}

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -144,10 +144,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,target=flash-attention/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
-    export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 8 12)" && \
-    export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
-    export PYTHONUNBUFFERED=1 && \
+    export CC=$(realpath -e ./compiler) \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 8 12)" \
+      NVCC_APPEND_FLAGS='-diag-suppress 186,177' \
+      PYTHONUNBUFFERED=1 \
+      FLASH_ATTENTION_FORCE_BUILD='TRUE' && \
     cd flash-attention && \
     ( \
       for EXT_DIR in $(realpath -s -e \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -128,7 +128,7 @@ RUN python3 -m pip install -U --no-cache-dir \
       do if [[ -z ${!VAR} ]]; then unset ${VAR}; fi; done; \
     } && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 48)" \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 48)" \
       python3 -m pip wheel -w /wheels \
       --no-cache-dir --no-build-isolation --no-deps \
       deepspeed==${DEEPSPEED_VERSION} && \
@@ -180,7 +180,7 @@ RUN --mount=type=bind,from=apex-downloader,source=/git/apex,target=apex/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 48)" && \
+    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 48)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     printf -- '--config-settings="--build-option=%s" ' $( \
       echo \
@@ -223,7 +223,7 @@ ARG XFORMERS_VERSION
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 1 24)" \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 24)" \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -146,6 +146,7 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
     export CC=$(realpath -e ./compiler) && \
     export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 8 12)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
+    export PYTHONUNBUFFERED=1 && \
     cd flash-attention && \
     ( \
       for EXT_DIR in $(realpath -s -e \
@@ -162,7 +163,8 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
           cd - || \
           exit 1; \
       done; \
-    )
+    ) | \
+    grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores'
 
 WORKDIR /wheels
 

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -2,9 +2,9 @@
 
 ARG BASE_IMAGE
 ARG DEEPSPEED_VERSION="0.10.3"
-ARG FLASH_ATTN_VERSION="2.0.2"
+ARG FLASH_ATTN_VERSION="2.3.6"
 ARG APEX_COMMIT="38a12698bc3cc95987bca270bcd6d025bb0be346"
-ARG XFORMERS_VERSION="0.0.22"
+ARG XFORMERS_VERSION="0.0.22.post7"
 
 FROM alpine/git:2.36.3 as flash-attn-downloader
 WORKDIR /git
@@ -164,8 +164,8 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
           cd - || \
           exit 1; \
       done; \
-    ) 2> \
-    >(grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores' >&2)
+    ) | \
+    grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores'
 SHELL ["/bin/sh", "-c"]
 
 WORKDIR /wheels
@@ -230,6 +230,8 @@ RUN python3 -m pip install -U --no-cache-dir \
     CC=$(realpath -e ./compiler) \
       MAX_JOBS=1 \
       PYTHONUNBUFFERED=1 \
+      NVCC_APPEND_FLAGS='-diag-suppress 186,177' \
+      XFORMERS_DISABLE_FLASH_ATTN=1 \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -102,7 +102,7 @@ ARG DS_BUILD_AIO=""
 
 ARG DEEPSPEED_VERSION
 
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     if python3 -m pip show torch | grep 'Version: 2\.[1-9]' > /dev/null; then \
@@ -140,7 +140,7 @@ WORKDIR /wheels
 
 FROM builder-base as flash-attn-builder
 
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,target=flash-attention/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
@@ -224,7 +224,7 @@ FROM builder-base as xformers-builder
 
 ARG XFORMERS_VERSION
 
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -223,7 +223,7 @@ ARG XFORMERS_VERSION
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 12)" \
+      MAX_JOBS=1 \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -128,7 +128,7 @@ RUN python3 -m pip install -U --no-cache-dir \
       do if [[ -z ${!VAR} ]]; then unset ${VAR}; fi; done; \
     } && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 48)" \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 24)" \
       python3 -m pip wheel -w /wheels \
       --no-cache-dir --no-build-isolation --no-deps \
       deepspeed==${DEEPSPEED_VERSION} && \
@@ -144,7 +144,7 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 24)" && \
+    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 8 12)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     cd flash-attention && \
     ( \
@@ -180,7 +180,7 @@ RUN --mount=type=bind,from=apex-downloader,source=/git/apex,target=apex/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
     export CC=$(realpath -e ./compiler) && \
-    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 48)" && \
+    export MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 8 24)" && \
     export NVCC_APPEND_FLAGS='-diag-suppress 186,177' && \
     printf -- '--config-settings="--build-option=%s" ' $( \
       echo \
@@ -223,7 +223,7 @@ ARG XFORMERS_VERSION
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
-      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 24)" \
+      MAX_JOBS="$(./scale.sh "$(./effective_cpu_count.sh)" 4 12)" \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \

--- a/torch-extras/Dockerfile
+++ b/torch-extras/Dockerfile
@@ -140,6 +140,7 @@ WORKDIR /wheels
 
 FROM builder-base as flash-attn-builder
 
+SHELL ["/bin/bash", "-c"]
 RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,target=flash-attention/,rw \
     python3 -m pip install -U --no-cache-dir \
       packaging setuptools wheel pip && \
@@ -163,8 +164,9 @@ RUN --mount=type=bind,from=flash-attn-downloader,source=/git/flash-attention,tar
           cd - || \
           exit 1; \
       done; \
-    ) | \
-    grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores'
+    ) 2> \
+    >(grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores' >&2)
+SHELL ["/bin/sh", "-c"]
 
 WORKDIR /wheels
 
@@ -222,6 +224,7 @@ FROM builder-base as xformers-builder
 
 ARG XFORMERS_VERSION
 
+SHELL ["/bin/bash", "-c"]
 RUN python3 -m pip install -U --no-cache-dir \
       setuptools wheel pip && \
     CC=$(realpath -e ./compiler) \
@@ -230,8 +233,9 @@ RUN python3 -m pip install -U --no-cache-dir \
       python3 -m pip wheel -w /wheels -v \
       --no-cache-dir --no-build-isolation --no-deps \
       --no-binary=xformers \
-      xformers==${XFORMERS_VERSION} | \
-    grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores'
+      xformers==${XFORMERS_VERSION} 2> \
+    >(grep -Ev --line-buffered 'ptxas info\s*:|bytes spill stores' >&2)
+SHELL ["/bin/sh", "-c"]
 
 
 FROM ${BASE_IMAGE}

--- a/torch-extras/scale.sh
+++ b/torch-extras/scale.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e;
+
+VAL="$1";
+DIVISOR="$2";
+MAXIMUM="$3";
+
+[ -n "$VAL" ];
+
+if [ -n "$DIVISOR" ];
+then VAL="$((( $VAL + $DIVISOR - 1 ) / $DIVISOR))";
+fi;
+
+if [ -n "$MAXIMUM" ];
+then VAL="$((VAL > MAXIMUM ? MAXIMUM : VAL))";
+fi;
+
+echo "$VAL";


### PR DESCRIPTION
# Fix `xformers` & Limit Concurrency on `torch-extras` Builds

This change updates `flash-attention` to v2.3.6, and removes the `flash-attention` v1.0.9 builds. `xformers`'s bundled `flash-attention` is disabled so that it uses the manually built one, because `xformers`'s own `flash-attention` build currently segfaults on CUDA 12.1.

This change also adds hard limits on the number of threads used during `torch-extras` compilation jobs to avoid excessive RAM use.