### PR TITLE
feat(torch): Bundle `libsodium`

### DIFF
--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -284,7 +284,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install core packages
 RUN apt-get -qq update && apt-get -qq install -y \
       libncurses5 python3 python3-pip python3-distutils python3-numpy \
-      libpng16-16 libjpeg-turbo8 \
+      libpng16-16 libjpeg-turbo8 libsodium23 \
       curl git apt-utils ssh ca-certificates tmux nano vim-tiny sudo bash \
       rsync htop wget unzip tini && \
     /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
## `libsodium` with `torch`

This change installs `libsodium23` through `apt-get` along with other core packages. This allows supporting coreweave/tensorizer#66 encryption out of the box. The image size footprint of adding this library is under 500 KiB.