### PR TITLE
fix(hf-llm-inference): Update `hf-llm-inference` source commit

### DIFF
--- a/hf-llm-inference/Dockerfile
+++ b/hf-llm-inference/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update && \
 RUN mkdir /app
 WORKDIR /app
 
-ARG COMMIT=4ff78daa65b6a4a944c5f14f102e5f28770bcfcc
+ARG COMMIT=2ce545a83c1e85d12f7b23657586e038f0901373
 RUN git clone --filter=blob:none https://github.com/coreweave/kubernetes-cloud && \
     cd kubernetes-cloud && \
     git checkout ${COMMIT} && \

--- a/hf-llm-inference/Dockerfile
+++ b/hf-llm-inference/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update && \
 RUN mkdir /app
 WORKDIR /app
 
-ARG COMMIT=2ce545a83c1e85d12f7b23657586e038f0901373
+ARG COMMIT=cfd8b249a6bac47e0b3dab6fa2be781965a69025
 RUN git clone --filter=blob:none https://github.com/coreweave/kubernetes-cloud && \
     cd kubernetes-cloud && \
     git checkout ${COMMIT} && \


### PR DESCRIPTION
# HF LLM Inference Updates

This updates the source commit of the `hf-llm-inference` image to coreweave/kubernetes-cloud@cfd8b249a6bac47e0b3dab6fa2be781965a69025 to include new bug fixes.