### PR TITLE
fix(tensorizer): Use `torch-base` base image

### DIFF
--- a/tensorizer/Dockerfile
+++ b/tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM ghcr.io/coreweave/ml-containers/torch:es-22.04-3ce72cc-base-cuda12.2.2-torch2.1.2-vision0.16.2-audio2.1.2
 ARG COMMIT=main
 
 RUN mkdir /app
@@ -7,7 +7,4 @@ WORKDIR /app
 RUN git clone https://github.com/coreweave/tensorizer && \
     cd tensorizer && \
     git checkout ${COMMIT} && \
-    pip3 install . && \
-    cd ..
-
-CMD ["python3", "-m", "tensorizer.tensorizer"]
+    pip3 install .


### PR DESCRIPTION
Quick adjustment to `tensorizer` Dockerfile to use a `torch-base` image and not have a `CMD` nor `ENTRYPOINT` instruction. 