### PR TITLE
fix(build): move buildcache for clarity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ inputs.image-name }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ inputs.image-name }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/buildcache:${{ inputs.image-name }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/buildcache:${{ inputs.image-name }},mode=max
       - uses: 8BitJonny/gh-get-current-pr@2.1.3
         id: PR
         with:

--- a/.github/workflows/torch-extras.yml
+++ b/.github/workflows/torch-extras.yml
@@ -141,6 +141,8 @@ jobs:
     name: Build torch-extras via Workflow Call
     if: inputs.skip-bases-check
     strategy:
+      # if you need to build for multiple versions of flash-attn
+      # fix tag-suffix below to reflect your versions in the tag
       matrix:
         flash-attn: [ 2.4.2 ]
     uses: ./.github/workflows/build.yml
@@ -148,7 +150,8 @@ jobs:
     with:
       image-name: ${{ inputs.image-name || 'torch-extras' }}
       folder: torch-extras
-      tag-suffix: ${{ inputs.tag }}-flash_attn${{ matrix.flash-attn }}
+      #tag-suffix: ${{ inputs.tag }}-flash_attn${{ matrix.flash-attn }}
+      tag-suffix: ${{ inputs.tag }}
       build-args: |
         BASE_IMAGE=${{ inputs.base-image }}
         FLASH_ATTN_VERSION=${{ matrix.flash-attn }}

--- a/.github/workflows/torch-extras.yml
+++ b/.github/workflows/torch-extras.yml
@@ -159,6 +159,8 @@ jobs:
     if: needs.get-required-bases.outputs.bases-list && needs.get-required-bases.outputs.bases-list != '[]'
     strategy:
       matrix:
+        # if you need to build for multiple versions of flash-attn
+        # fix tag-suffix below to reflect your versions in the tag
         flash-attn: [ 2.4.2 ]
         bases: ${{ fromJSON(needs.get-required-bases.outputs.bases-list) }}
     uses: ./.github/workflows/build.yml
@@ -166,7 +168,8 @@ jobs:
     with:
       image-name: ${{ inputs.image-name || 'torch-extras' }}
       folder: torch-extras
-      tag-suffix: ${{ matrix.bases.tag }}-flash_attn${{ matrix.flash-attn }}
+      #tag-suffix: ${{ matrix.bases.tag }}-flash_attn${{ matrix.flash-attn }}
+      tag-suffix: ${{ matrix.bases.tag }}
       build-args: |
         BASE_IMAGE=${{ matrix.bases.image }}
         FLASH_ATTN_VERSION=${{ matrix.flash-attn }}

--- a/.github/workflows/torch-nightly.yml
+++ b/.github/workflows/torch-nightly.yml
@@ -82,7 +82,7 @@ jobs:
             >> "$GITHUB_OUTPUT";
       - name: Get date
         id: get-date
-        run: echo "date=$(date -u '+%Y.%m.%d.%H')" >> "$GITHUB_OUTPUT";
+        run: echo "date=$(date -u '+%y%m%d%H')" >> "$GITHUB_OUTPUT";
 
   get-base-config:
     name: Get torch:base Config


### PR DESCRIPTION
This change moves all the buildcache images to their own page.

On packages that use a build cache, that tag is currently appearing at the top of the page for that image. This is causing confusion amongst users who assume the top-most tag is functionally equivalent to `:latest`. see #59.