### PR TITLE
build(torch): Error on timeouts while fetching packages

### DIFF
--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -106,8 +106,7 @@ RUN CODENAME="$(lsb_release -cs)" && \
     wget -qO - 'https://apt.llvm.org/llvm-snapshot.gpg.key' > /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     apt-add-repository -n "deb https://apt.llvm.org/$CODENAME/ llvm-toolchain-$CODENAME-17 main" && \
     apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
-    | tee /dev/tty \
-    | { ! grep -q 'W:.*connection timed out'; } && \
+    | sed -e '/connection timed out/{p; Q1}' && \
     apt-get -qq install --no-install-recommends -y gcc-11 g++-11 lld-17 && \
     apt-get clean && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
@@ -299,8 +298,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
         software-properties-common && \
     apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
-    | tee /dev/tty \
-    | { ! grep -q 'W:.*connection timed out'; } && \
+    | sed -e '/connection timed out/{p; Q1}' && \
     apt-get -qq install -y --no-install-recommends libstdc++6 && \
     apt-get clean
 

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -98,16 +98,17 @@ RUN apt-get -qq update && apt-get -qq install -y \
       software-properties-common lsb-release && \
     { wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc \
     | gpg --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg; } && \
-    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-add-repository -n "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
     apt-get -qq update && apt-get -qq install -y cmake && apt-get clean
 
 # Update compiler (GCC) and linker (LLD) versions
 RUN CODENAME="$(lsb_release -cs)" && \
     wget -qO - 'https://apt.llvm.org/llvm-snapshot.gpg.key' > /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    apt-add-repository "deb https://apt.llvm.org/$CODENAME/ llvm-toolchain-$CODENAME-17 main" && \
-    apt-add-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get -qq update && apt-get -qq install --no-install-recommends -y \
-      gcc-11 g++-11 lld-17 && \
+    apt-add-repository -n "deb https://apt.llvm.org/$CODENAME/ llvm-toolchain-$CODENAME-17 main" && \
+    apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
+    | tee /dev/tty \
+    | { ! grep -q 'W:.*timeout'; } && \
+    apt-get -qq install --no-install-recommends -y gcc-11 g++-11 lld-17 && \
     apt-get clean && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 11 && \
@@ -297,7 +298,9 @@ RUN apt-get -qq update && apt-get -qq install -y \
 
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
         software-properties-common && \
-    apt-add-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
+    | tee /dev/tty \
+    | { ! grep -q 'W:.*timeout'; } && \
     apt-get -qq install -y --no-install-recommends libstdc++6 && \
     apt-get clean
 

--- a/torch/Dockerfile
+++ b/torch/Dockerfile
@@ -107,7 +107,7 @@ RUN CODENAME="$(lsb_release -cs)" && \
     apt-add-repository -n "deb https://apt.llvm.org/$CODENAME/ llvm-toolchain-$CODENAME-17 main" && \
     apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
     | tee /dev/tty \
-    | { ! grep -q 'W:.*timeout'; } && \
+    | { ! grep -q 'W:.*connection timed out'; } && \
     apt-get -qq install --no-install-recommends -y gcc-11 g++-11 lld-17 && \
     apt-get clean && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11 && \
@@ -300,7 +300,7 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
         software-properties-common && \
     apt-add-repository -y ppa:ubuntu-toolchain-r/test 2>&1 \
     | tee /dev/tty \
-    | { ! grep -q 'W:.*timeout'; } && \
+    | { ! grep -q 'W:.*connection timed out'; } && \
     apt-get -qq install -y --no-install-recommends libstdc++6 && \
     apt-get clean
 


### PR DESCRIPTION
# Error on `apt-get update` timeouts

Sometimes, `apt` would semi-silently fail to fetch packages while adding the `ppa:ubuntu-toolchain-r/test` package repository, emitting a warning, but also a successful exit code. This change checks for that warning and fails the build, since it is inappropriate to continue if those packages could not be properly updated.