### PR TITLE
ci(torch): Update `nccl-tests` base images and `torch` patch release

### DIFF
--- a/.github/configurations/torch-base.yml
+++ b/.github/configurations/torch-base.yml
@@ -5,6 +5,6 @@ exclude:
   - cuda: 11.8.0
     os: ubuntu22.04
 include:
-  - torch: 2.2.0
-    vision: 0.17.0
-    audio: 2.2.0
+  - torch: 2.2.2
+    vision: 0.17.2
+    audio: 2.2.2

--- a/.github/configurations/torch-nccl.yml
+++ b/.github/configurations/torch-nccl.yml
@@ -30,6 +30,6 @@ image:
     nccl: 2.16.5-1
     nccl-tests-hash: 868dc3d
 include:
-  - torch: 2.2.0
-    vision: 0.17.0
-    audio: 2.2.0
+  - torch: 2.2.2
+    vision: 0.17.2
+    audio: 2.2.2

--- a/.github/configurations/torch-nccl.yml
+++ b/.github/configurations/torch-nccl.yml
@@ -3,32 +3,32 @@ image:
   - cuda: 12.2.2
     os: ubuntu22.04
     nccl: 2.19.3-1
-    nccl-tests-hash: a72ab6c
+    nccl-tests-hash: 868dc3d
   - cuda: 12.1.1
     os: ubuntu22.04
     nccl: 2.18.3-1
-    nccl-tests-hash: a72ab6c
+    nccl-tests-hash: 868dc3d
   - cuda: 12.0.1
     os: ubuntu22.04
     nccl: 2.18.5-1
-    nccl-tests-hash: a72ab6c
+    nccl-tests-hash: 868dc3d
   # Ubuntu 20.04
   - cuda: 12.2.2
     os: ubuntu20.04
-    nccl: 2.19.3-1
-    nccl-tests-hash: fb613ea
+    nccl: 2.20.3-1
+    nccl-tests-hash: 868dc3d
   - cuda: 12.1.1
     os: ubuntu20.04
     nccl: 2.18.3-1
-    nccl-tests-hash: fb613ea
+    nccl-tests-hash: 868dc3d
   - cuda: 12.0.1
     os: ubuntu20.04
     nccl: 2.19.3-1
-    nccl-tests-hash: fb613ea
+    nccl-tests-hash: 868dc3d
   - cuda: 11.8.0
     os: ubuntu20.04
     nccl: 2.16.5-1
-    nccl-tests-hash: fb613ea
+    nccl-tests-hash: 868dc3d
 include:
   - torch: 2.2.0
     vision: 0.17.0


### PR DESCRIPTION
# Update `nccl` bases & PyTorch

This change updates the base image for `torch:nccl` images to the 868dc3d tag, which notably includes NCCL v2.20.3 for Ubuntu 20.04. This also updates the micro version of PyTorch from 2.2.0 to 2.2.2 for its latest fixes.