### PR TITLE
feat(vllm-tensorizer): Upgrade vLLM version and Resolve Related Build Compatibility Issues

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,2 +1,6 @@
-vllm-commit: ['b6553be1bc75f046b00046a4ad7576364d03c835']
-base-image: ['ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1']
+vllm-commit:
+  - 'b6553be1bc75f046b00046a4ad7576364d03c835'
+flashinfer-commit:
+  - 'v0.2.6.post1'
+base-image:
+  - 'ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,0 +1,2 @@
+vllm-commit: ['b6553be1bc75f046b00046a4ad7576364d03c835']
+base-image: ['ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1']

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -23,5 +23,6 @@ jobs:
       folder: vllm-tensorizer
       tag-suffix: ${{ matrix.vllm-commit }}
       build-args: |
-        VLLM_COMMIT_HASH=${{ matrix.vllm-commit }}
+        VLLM_COMMIT=${{ matrix.vllm-commit }}
+        FLASHINFER_COMMIT=${{ matrix.flashinfer-commit }}
         BASE_IMAGE=${{ matrix.base-image }}

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}
+      tag-suffix: ${{ inputs.commit || '5e4f640d22b0e4b50f506ce913d01fd471ad8086'}}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}
+        COMMIT_HASH=${{ inputs.commit || '5e4f640d22b0e4b50f506ce913d01fd471ad8086'}}
         TRITON_COMMIT=96316ce5

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   get-config:
-    name: Get torch:base Config
+    name: Get vllm-tensorizer config
     uses: ./.github/workflows/read-configuration.yml
     with:
       path: ./.github/configurations/vllm-tensorizer.yml

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -21,4 +21,3 @@ jobs:
       tag-suffix: ${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
       build-args: |
         COMMIT_HASH=${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
-        TRITON_COMMIT=96316ce5

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
+      tag-suffix: ${{ inputs.commit || '58738772410c5e0d60b61db39538a9b313d2d7ad'}}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
+        COMMIT_HASH=${{ inputs.commit || '58738772410c5e0d60b61db39538a9b313d2d7ad'}}
         TRITON_COMMIT=96316ce5

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -1,9 +1,4 @@
 on:
-  workflow_dispatch:
-    inputs:
-      commit:
-        description: 'Commit to build'
-        required: true
   push:
     paths:
       - "vllm-tensorizer/**"
@@ -12,12 +7,21 @@ on:
 
 
 jobs:
+  get-config:
+    name: Get torch:base Config
+    uses: ./.github/workflows/read-configuration.yml
+    with:
+      path: ./.github/configurations/vllm-tensorizer.yml
   build:
     uses: ./.github/workflows/build.yml
+    needs: get-config
+    strategy:
+      matrix: ${{ fromJSON(needs.get-config.outputs.config) }}
     secrets: inherit
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
+      tag-suffix: ${{ matrix.vllm-commit }}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
+        VLLM_COMMIT_HASH=${{ matrix.vllm-commit }}
+        BASE_IMAGE=${{ matrix.base-image }}

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -21,3 +21,4 @@ jobs:
       tag-suffix: ${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}
       build-args: |
         COMMIT_HASH=${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}
+        TRITON_COMMIT=96316ce5

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || '5e4f640d22b0e4b50f506ce913d01fd471ad8086'}}
+      tag-suffix: ${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || '5e4f640d22b0e4b50f506ce913d01fd471ad8086'}}
+        COMMIT_HASH=${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
         TRITON_COMMIT=96316ce5

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,6 +18,6 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || '19307ba71ddeb7e1cc6aec3c1baa8b50d59c1beb'}}
+      tag-suffix: ${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || '19307ba71ddeb7e1cc6aec3c1baa8b50d59c1beb'}}
+        COMMIT_HASH=${{ inputs.commit || '85e2b7bb1380dd7096e0d6b64b0d7633b0a9db4a'}}

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ inputs.commit || '58738772410c5e0d60b61db39538a9b313d2d7ad'}}
+      tag-suffix: ${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
       build-args: |
-        COMMIT_HASH=${{ inputs.commit || '58738772410c5e0d60b61db39538a9b313d2d7ad'}}
+        COMMIT_HASH=${{ inputs.commit || 'b6553be1bc75f046b00046a4ad7576364d03c835'}}
         TRITON_COMMIT=96316ce5

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ flycheck_*.el
 .env*
 .environment
 .environment*
+
+# JetBrains Idea files
+.idea/

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -58,7 +58,6 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
 find_package(CUDA REQUIRED)\n\
 find_library(NVTOOLSEXT_LIBRARY\n\
              NAMES nvToolsExt\n\
-             PATH_SUFFIXES lib)\n\
 \n\
 if (NVTOOLSEXT_LIBRARY)\n\
     message(STATUS "Found nvToolsExt library: ${NVTOOLSEXT_LIBRARY}")\n\

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.0-audio2.7.0-abi1"
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.0-abi1"
 FROM scratch as freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
+ARG BASE_IMAGE="FROM ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-base-cuda12.8.1-ubuntu22.04-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
 FROM scratch AS freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -54,6 +54,22 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
     if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
+    sed -i '/^find_package(Torch REQUIRED)/i\
+find_package(CUDA REQUIRED)\n\
+find_library(NVTOOLSEXT_LIBRARY\n\
+             NAMES nvToolsExt\n\
+             PATH_SUFFIXES lib)\n\
+\n\
+if (NVTOOLSEXT_LIBRARY)\n\
+    message(STATUS "Found nvToolsExt library: ${NVTOOLSEXT_LIBRARY}")\n\
+else()\n\
+    message(FATAL_ERROR "Could not find nvToolsExt library")\n\
+endif()\n\
+add_library(CUDA::nvToolsExt SHARED IMPORTED)\n\
+set_target_properties(CUDA::nvToolsExt PROPERTIES\n\
+ IMPORTED_LOCATION ${NVTOOLSEXT_LIBRARY}\n\
+)\n\
+\n' CMakeLists.txt && \
     LIBRARY_PATH="/usr/local/cuda/lib64:${LIBRARY_PATH:+:$LIBRARY_PATH}" \
     CUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda" \
       python3 -m pip wheel -w /wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -55,14 +55,26 @@ FROM ${BASE_IMAGE} AS base
 
 WORKDIR /workspace
 
-RUN apt-get -qq update && apt-get install -y --no-install-recommends curl && apt-get clean
+RUN apt-get -qq update && apt-get install -y --no-install-recommends curl libsodium23 && apt-get clean
 
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
-    python3 -m pip install --no-cache-dir /tmp/wheels/*.whl -c /tmp/constraints.txt && \
-    rm /tmp/constraints.txt
+    python3 -m pip install --no-cache-dir "$(printf '%s[tensorizer]' /tmp/wheels/*.whl)" -c /tmp/constraints.txt
 
+# Copied from vLLM's Dockerfile
+ARG TARGETPLATFORM
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        python3 -m pip install --no-cache-dir \
+          accelerate hf_transfer 'modelscope!=1.15.0' 'bitsandbytes>=0.42.0' 'timm==0.9.10' \
+          boto3 runai-model-streamer runai-model-streamer[s3] -c /tmp/constraints.txt; \
+    else \
+        python3 -m pip install --no-cache-dir \
+          accelerate hf_transfer 'modelscope!=1.15.0' 'bitsandbytes>=0.45.3' 'timm==0.9.10' \
+          boto3 runai-model-streamer runai-model-streamer[s3] -c /tmp/constraints.txt; \
+    fi && \
+    rm /tmp/constraints.txt
 
 EXPOSE 8080

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -15,20 +15,35 @@ RUN apt-get -qq update && \
     apt-get clean && \
     pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm regex
 
+# Create the /wheels directory
+WORKDIR /wheels
+
+WORKDIR /workspace
+
+
 FROM alpine/git:2.36.3 AS vllm-downloader
 WORKDIR /git
-ARG VLLM_COMMIT_HASH
-RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
-      https://github.com/vllm-project/vllm.git && \
+ARG VLLM_COMMIT
+RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
+      https://github.com/vllm-project/vllm && \
     cd vllm && \
-    git checkout "${VLLM_COMMIT_HASH}" && \
+    git checkout "${VLLM_COMMIT}" && \
     git submodule update --init --recursive --jobs 8 \
-      --depth 1 --filter=blob:none
+      --depth 1 --filter=tree:0
+
+
+FROM alpine/git:2.36.3 AS flashinfer-downloader
+WORKDIR /git
+ARG FLASHINFER_COMMIT
+RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
+      https://github.com/flashinfer-ai/flashinfer && \
+    cd flashinfer && \
+    git checkout "${FLASHINFER_COMMIT}" && \
+    git submodule update --init --recursive --jobs 8 \
+      --depth 1 --filter=tree:0
 
 
 FROM builder-base AS vllm-builder
-WORKDIR /workspace
-
 RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw \
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
@@ -51,6 +66,21 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
 
 WORKDIR /wheels
 
+
+FROM builder-base AS flashinfer-builder
+RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/workspace,rw \
+    --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
+    /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
+    export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST/7.0 /}" && \
+    python3 -m flashinfer.aot && \
+    python3 -m pip wheel -w /wheels \
+      -v --no-cache-dir --no-build-isolation --no-deps \
+      -c /tmp/frozen/constraints.txt \
+      ./
+
+WORKDIR /wheels
+
+
 FROM ${BASE_IMAGE} AS base
 
 WORKDIR /workspace
@@ -62,6 +92,9 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir "$(printf '%s[tensorizer]' /tmp/wheels/*.whl)" -c /tmp/constraints.txt
+
+RUN --mount=type=bind,from=flashinfer-builder,source=/wheels,target=/tmp/wheels \
+    python3 -m pip install --no-cache-dir /tmp/wheels/*.whl -c /tmp/constraints.txt
 
 # Copied from vLLM's Dockerfile
 ARG TARGETPLATFORM

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -46,8 +46,24 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=blob:none
 
+# Testing
+FROM alpine/git:2.36.3 as triton-downloader
+WORKDIR /git
+ARG TRITON_COMMIT="96316ce5"
+RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout https://github.com/openai/triton.git && \
+    cd triton && \
+    git checkout "${TRITON_COMMIT}" && \
+    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none \
+# Testing end
+
 FROM builder-base as vllm-builder
 WORKDIR /workspace
+
+# Testing
+RUN --mount=type=bind,from=triton-builder,source=/wheels,target=/tmp/triton-wheels \
+    python3 -m pip install --no-cache-dir /tmp/triton-wheels/*.whl && \
+    rm -rf /tmp/triton-wheels \
+# Testing end
 RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw \
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
@@ -60,6 +76,16 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
 WORKDIR /wheels
 
 FROM ${BASE_IMAGE} as base
+
+# Testing
+FROM builder-base as triton-builder
+WORKDIR /workspace
+RUN --mount=type=bind,from=triton-downloader,source=/git/triton,target=/workspace,rw \
+    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+    python3 -m pip wheel -w /wheels \
+    -v --no-cache-dir --no-build-isolation --no-deps \
+    ./
+# Testing end
 
 WORKDIR /workspace
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -72,6 +72,8 @@ RUN apt-get -qq update && apt-get install -y --no-install-recommends curl && apt
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
+RUN sed -i '/xformers==/d' /tmp/constraints.txt
+
 RUN python3 -m pip install --no-cache-dir \
       "fschat[model_worker] == 0.2.30" \
       -c /tmp/constraints.txt

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -5,7 +5,7 @@ COPY --chmod=755 freeze.sh /
 
 FROM ${BASE_IMAGE} as builder-base
 
-ARG MAX_JOBS=""
+ARG MAX_JOBS="2"
 
 # Dependencies requiring NVCC are built ahead of time in a separate stage
 # so that the ~2 GiB dev library installations don't have to be included

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -10,23 +10,23 @@ ARG MAX_JOBS=""
 # Dependencies requiring NVCC are built ahead of time in a separate stage
 # so that the ~2 GiB dev library installations don't have to be included
 # in the final image.
-RUN export \
-      CUDA_MAJOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f1) \
-      CUDA_MINOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f2) && \
-    export \
-      CUDA_PACKAGE_VERSION="${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}" && \
-    apt-get -qq update && apt-get install -y --no-install-recommends \
-      cuda-nvcc-${CUDA_PACKAGE_VERSION} \
-      cuda-nvml-dev-${CUDA_PACKAGE_VERSION} \
-      libcurand-dev-${CUDA_PACKAGE_VERSION} \
-      libcublas-dev-${CUDA_PACKAGE_VERSION} \
-      libcusparse-dev-${CUDA_PACKAGE_VERSION} \
-      libcusolver-dev-${CUDA_PACKAGE_VERSION} \
-      cuda-nvprof-${CUDA_PACKAGE_VERSION} \
-      cuda-profiler-api-${CUDA_PACKAGE_VERSION} \
-      libaio-dev \
-      ninja-build && \
-    apt-get clean
+#RUN export \
+#      CUDA_MAJOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f1) \
+#      CUDA_MINOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f2) && \
+#    export \
+#      CUDA_PACKAGE_VERSION="${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}" && \
+#    apt-get -qq update && apt-get install -y --no-install-recommends \
+#      cuda-nvcc-${CUDA_PACKAGE_VERSION} \
+#      cuda-nvml-dev-${CUDA_PACKAGE_VERSION} \
+#      libcurand-dev-${CUDA_PACKAGE_VERSION} \
+#      libcublas-dev-${CUDA_PACKAGE_VERSION} \
+#      libcusparse-dev-${CUDA_PACKAGE_VERSION} \
+#      libcusolver-dev-${CUDA_PACKAGE_VERSION} \
+#      cuda-nvprof-${CUDA_PACKAGE_VERSION} \
+#      cuda-profiler-api-${CUDA_PACKAGE_VERSION} \
+#      libaio-dev \
+#      ninja-build && \
+#    apt-get clean
 
 RUN ldconfig
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -74,10 +74,6 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
 
 RUN sed -i '/xformers==/d' /tmp/constraints.txt
 
-RUN python3 -m pip install --no-cache-dir \
-      "fschat[model_worker] == 0.2.30" \
-      -c /tmp/constraints.txt
-
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir /tmp/wheels/*.whl -c /tmp/constraints.txt && \
     rm /tmp/constraints.txt

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
 RUN python3 -m pip install --no-cache-dir \
-      "fschat[model_worker] == 0.2.30" "triton == 3.3.1" \
+      "fschat[model_worker] == 0.2.30" "triton == 2.3.1" \
       -c /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
     if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
     sed -i '/^find_package(Torch REQUIRED)/i\
 find_package(CUDA REQUIRED)\n\
-find_library(NVTOOLSEXT_LIBRARY\n\
+find_library(NVTOOLSEXT_LIBRARY)\n\
              NAMES nvToolsExt\n\
 \n\
 if (NVTOOLSEXT_LIBRARY)\n\

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -5,7 +5,7 @@ COPY --chmod=755 freeze.sh /
 
 FROM ${BASE_IMAGE} as builder-base
 
-ARG MAX_JOBS="2"
+ARG MAX_JOBS="8"
 
 # Dependencies requiring NVCC are built ahead of time in a separate stage
 # so that the ~2 GiB dev library installations don't have to be included

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -36,6 +36,24 @@ RUN apt-get -qq update && \
     apt-get clean && \
     pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm
 
+# Testing
+FROM alpine/git:2.36.3 as triton-downloader
+WORKDIR /git
+ARG TRITON_COMMIT="96316ce5"
+RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout https://github.com/openai/triton.git && \
+    cd triton && \
+    git checkout "${TRITON_COMMIT}" && \
+    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none \
+
+FROM builder-base as triton-builder
+WORKDIR /workspace
+RUN --mount=type=bind,from=triton-downloader,source=/git/triton,target=/workspace,rw \
+    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+    python3 -m pip wheel -w /wheels \
+    -v --no-cache-dir --no-build-isolation --no-deps \
+    ./
+# Testing end
+
 FROM alpine/git:2.36.3 as vllm-downloader
 WORKDIR /git
 ARG COMMIT_HASH
@@ -46,15 +64,6 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=blob:none
 
-# Testing
-FROM alpine/git:2.36.3 as triton-downloader
-WORKDIR /git
-ARG TRITON_COMMIT="96316ce5"
-RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout https://github.com/openai/triton.git && \
-    cd triton && \
-    git checkout "${TRITON_COMMIT}" && \
-    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none \
-# Testing end
 
 FROM builder-base as vllm-builder
 WORKDIR /workspace
@@ -76,16 +85,6 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
 WORKDIR /wheels
 
 FROM ${BASE_IMAGE} as base
-
-# Testing
-FROM builder-base as triton-builder
-WORKDIR /workspace
-RUN --mount=type=bind,from=triton-downloader,source=/git/triton,target=/workspace,rw \
-    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
-    python3 -m pip wheel -w /wheels \
-    -v --no-cache-dir --no-build-isolation --no-deps \
-    ./
-# Testing end
 
 WORKDIR /workspace
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.0-vision0.22.0-audio2.7.0-abi1"
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.0-vision0.22.0-audio2.7.0-abi1"
 FROM scratch as freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
-FROM scratch AS freezer
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
 WORKDIR /
 COPY --chmod=755 freeze.sh /
 
@@ -59,8 +58,6 @@ RUN apt-get -qq update && apt-get install -y --no-install-recommends curl && apt
 
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
-
-RUN sed -i '/xformers==/d' /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir /tmp/wheels/*.whl -c /tmp/constraints.txt && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-22.04-58a49a2-base-cuda12.1.1-torch2.1.2-vision0.16.2-audio2.1.2-flash_attn2.4.2"
-
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.0-vision0.22.0-audio2.7.0-abi1"
 FROM scratch as freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -71,7 +71,7 @@ FROM builder-base AS flashinfer-builder
 RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/workspace,rw \
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
-    export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST/7.0 /}" && \
+    export TORCH_CUDA_ARCH_LIST="$(echo "${TORCH_CUDA_ARCH_LIST}" | sed 's@[67]\.0 \+@@g')" && \
     python3 -m flashinfer.aot && \
     python3 -m pip wheel -w /wheels \
       -v --no-cache-dir --no-build-isolation --no-deps \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
+FROM scratch AS freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -36,24 +36,6 @@ RUN apt-get -qq update && \
     apt-get clean && \
     pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm
 
-# Testing
-FROM alpine/git:2.36.3 as triton-downloader
-WORKDIR /git
-ARG TRITON_COMMIT="96316ce5"
-RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout https://github.com/openai/triton.git && \
-    cd triton && \
-    git checkout "${TRITON_COMMIT}" && \
-    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none
-
-FROM builder-base as triton-builder
-WORKDIR /workspace
-RUN --mount=type=bind,from=triton-downloader,source=/git/triton,target=/workspace,rw \
-    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
-    python3 -m pip wheel -w /wheels \
-    -v --no-cache-dir --no-build-isolation --no-deps \
-    ./
-# Testing end
-
 FROM alpine/git:2.36.3 as vllm-downloader
 WORKDIR /git
 ARG COMMIT_HASH
@@ -68,14 +50,10 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
 FROM builder-base as vllm-builder
 WORKDIR /workspace
 
-# Testing
-RUN --mount=type=bind,from=triton-builder,source=/wheels,target=/tmp/triton-wheels \
-    python3 -m pip install --no-cache-dir /tmp/triton-wheels/*.whl && \
-    rm -rf /tmp/triton-wheels
-# Testing end
 RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw \
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
+    if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
     LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
       python3 -m pip wheel -w /wheels \
       -v --no-cache-dir --no-build-isolation --no-deps \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
 RUN python3 -m pip install --no-cache-dir \
-      "fschat[model_worker] == 0.2.30" "triton == 2.58.0" \
+      "fschat[model_worker] == 0.2.30" "triton == 3.3.1" \
       -c /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
       python3-pip git ninja-build cmake && \
     apt-get clean && \
-    pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm
+    pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm regex
 
 FROM alpine/git:2.36.3 as vllm-downloader
 WORKDIR /git

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-base-cuda12.8.1-ubuntu22.04-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
 FROM scratch AS freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
 RUN python3 -m pip install --no-cache-dir \
-      "fschat[model_worker] == 0.2.30" "triton == 2.3.1" \
+      "fschat[model_worker] == 0.2.30" \
       -c /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.0-abi1"
-FROM scratch as freezer
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
+FROM scratch AS freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /
 
-FROM ${BASE_IMAGE} as builder-base
+FROM ${BASE_IMAGE} AS builder-base
 
 ARG MAX_JOBS="10"
 
@@ -15,7 +15,7 @@ RUN apt-get -qq update && \
     apt-get clean && \
     pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm regex
 
-FROM alpine/git:2.36.3 as vllm-downloader
+FROM alpine/git:2.36.3 AS vllm-downloader
 WORKDIR /git
 ARG COMMIT_HASH
 RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
@@ -26,7 +26,7 @@ RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
       --depth 1 --filter=blob:none
 
 
-FROM builder-base as vllm-builder
+FROM builder-base AS vllm-builder
 WORKDIR /workspace
 
 RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw \
@@ -42,7 +42,7 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
 
 WORKDIR /wheels
 
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 
 WORKDIR /workspace
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="FROM ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-base-cuda12.8.1-ubuntu22.04-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-2bf6b9c-base-cuda12.8.1-ubuntu22.04-torch2.7.1-vision0.22.1-audio2.7.1-abi1"
 FROM scratch AS freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -5,7 +5,7 @@ COPY --chmod=755 freeze.sh /
 
 FROM ${BASE_IMAGE} AS builder-base
 
-ARG MAX_JOBS="10"
+ARG MAX_JOBS="16"
 
 RUN ldconfig
 
@@ -33,6 +33,15 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
     if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
+    python3 -m pip install --no-cache-dir py-cpuinfo && \
+    if [ -f 'use_existing_torch.py' ]; then \
+      python3 use_existing_torch.py; \
+    else \
+      git cat-file blob \
+        e489ad7a210f4234db696d1f2749d5f3662fa65b:use_existing_torch.py \
+        | python3 -; \
+    fi && \
+    USE_CUDNN=1 USE_CUSPARSELT=1 \
     LIBRARY_PATH="/usr/local/cuda/lib64:${LIBRARY_PATH:+:$LIBRARY_PATH}" \
     CUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda" \
       python3 -m pip wheel -w /wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -40,7 +40,7 @@ FROM alpine/git:2.36.3 as vllm-downloader
 WORKDIR /git
 ARG COMMIT_HASH
 RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
-      https://github.com/coreweave/vllm.git && \
+      https://github.com/vllm-project/vllm.git && \
     cd vllm && \
     git checkout "${COMMIT_HASH}" && \
     git submodule update --init --recursive --jobs 8 \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get -qq update && \
 
 FROM alpine/git:2.36.3 AS vllm-downloader
 WORKDIR /git
-ARG COMMIT_HASH
+ARG VLLM_COMMIT_HASH
 RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout \
       https://github.com/vllm-project/vllm.git && \
     cd vllm && \
-    git checkout "${COMMIT_HASH}" && \
+    git checkout "${VLLM_COMMIT_HASH}" && \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=blob:none
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,32 +1,11 @@
-ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.0-vision0.22.0-audio2.7.0-abi1"
+ARG BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch-extras:00b897e-nccl-cuda12.8.1-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.0-audio2.7.0-abi1"
 FROM scratch as freezer
 WORKDIR /
 COPY --chmod=755 freeze.sh /
 
 FROM ${BASE_IMAGE} as builder-base
 
-ARG MAX_JOBS="8"
-
-# Dependencies requiring NVCC are built ahead of time in a separate stage
-# so that the ~2 GiB dev library installations don't have to be included
-# in the final image.
-#RUN export \
-#      CUDA_MAJOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f1) \
-#      CUDA_MINOR_VERSION=$(echo $CUDA_VERSION | cut -d. -f2) && \
-#    export \
-#      CUDA_PACKAGE_VERSION="${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}" && \
-#    apt-get -qq update && apt-get install -y --no-install-recommends \
-#      cuda-nvcc-${CUDA_PACKAGE_VERSION} \
-#      cuda-nvml-dev-${CUDA_PACKAGE_VERSION} \
-#      libcurand-dev-${CUDA_PACKAGE_VERSION} \
-#      libcublas-dev-${CUDA_PACKAGE_VERSION} \
-#      libcusparse-dev-${CUDA_PACKAGE_VERSION} \
-#      libcusolver-dev-${CUDA_PACKAGE_VERSION} \
-#      cuda-nvprof-${CUDA_PACKAGE_VERSION} \
-#      cuda-profiler-api-${CUDA_PACKAGE_VERSION} \
-#      libaio-dev \
-#      ninja-build && \
-#    apt-get clean
+ARG MAX_JOBS="10"
 
 RUN ldconfig
 

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -69,7 +69,7 @@ RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt
 
 RUN python3 -m pip install --no-cache-dir \
-      "fschat[model_worker] == 0.2.30" "triton == 2.1.0" \
+      "fschat[model_worker] == 0.2.30" "triton == 2.58.0" \
       -c /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -54,7 +54,8 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
     if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
-    LIBRARY_PATH="/usr/local/cuda/lib64/stubs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+    LIBRARY_PATH="/usr/local/cuda/lib64:${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+    CUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda" \
       python3 -m pip wheel -w /wheels \
       -v --no-cache-dir --no-build-isolation --no-deps \
       -c /tmp/frozen/constraints.txt \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -54,21 +54,6 @@ RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/frozen/constraints.txt && \
     if [ -z "$MAX_JOBS" ]; then unset MAX_JOBS; fi && \
-    sed -i '/^find_package(Torch REQUIRED)/i\
-find_package(CUDA REQUIRED)\n\
-find_library(NVTOOLSEXT_LIBRARY)\n\
-             NAMES nvToolsExt\n\
-\n\
-if (NVTOOLSEXT_LIBRARY)\n\
-    message(STATUS "Found nvToolsExt library: ${NVTOOLSEXT_LIBRARY}")\n\
-else()\n\
-    message(FATAL_ERROR "Could not find nvToolsExt library")\n\
-endif()\n\
-add_library(CUDA::nvToolsExt SHARED IMPORTED)\n\
-set_target_properties(CUDA::nvToolsExt PROPERTIES\n\
- IMPORTED_LOCATION ${NVTOOLSEXT_LIBRARY}\n\
-)\n\
-\n' CMakeLists.txt && \
     LIBRARY_PATH="/usr/local/cuda/lib64:${LIBRARY_PATH:+:$LIBRARY_PATH}" \
     CUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda" \
       python3 -m pip wheel -w /wheels \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -32,9 +32,9 @@ RUN ldconfig
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
-      python3-pip git ninja-build && \
+      python3-pip git ninja-build cmake && \
     apt-get clean && \
-    pip3 install -U --no-cache-dir pip packaging setuptools wheel
+    pip3 install -U --no-cache-dir pip packaging setuptools wheel setuptools_scm
 
 FROM alpine/git:2.36.3 as vllm-downloader
 WORKDIR /git

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -43,7 +43,7 @@ ARG TRITON_COMMIT="96316ce5"
 RUN git clone --filter=blob:none --depth 1 --no-single-branch --no-checkout https://github.com/openai/triton.git && \
     cd triton && \
     git checkout "${TRITON_COMMIT}" && \
-    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none \
+    git submodule update --init --recursive --jobs 8 --depth 1 --filter=blob:none
 
 FROM builder-base as triton-builder
 WORKDIR /workspace
@@ -71,7 +71,7 @@ WORKDIR /workspace
 # Testing
 RUN --mount=type=bind,from=triton-builder,source=/wheels,target=/tmp/triton-wheels \
     python3 -m pip install --no-cache-dir /tmp/triton-wheels/*.whl && \
-    rm -rf /tmp/triton-wheels \
+    rm -rf /tmp/triton-wheels
 # Testing end
 RUN --mount=type=bind,from=vllm-downloader,source=/git/vllm,target=/workspace,rw \
     --mount=type=bind,from=freezer,target=/tmp/frozen,rw \


### PR DESCRIPTION
This PR focuses on updating the vLLM version being used within the `vllm-tensorizer` Docker image and resolving the various bugs and compatibility issues that arose from this upgrade.

**Key Changes:**
  - **Updated Base Image:** Switched to `ghcr.io/coreweave/ml-containers/torch-extras:es-compute-12.0-67208ca-nccl-cuda12.9.0-ubuntu22.04-nccl2.27.3-1-torch2.7.1-vision0.22.1-audio2.7.1-abi1`. This moves from `torch:base` to `torch:nccl` for CUDA development tools and aligns with PyTorch 2.7.1 and CUDA 12.9.0.
  - **Upstream vLLM:** Updated vLLM source to pull from the official vllm-project/vllm.git repository (v0.9.1), rather than CoreWeave's vLLM fork
  - **Build Compatibility:** Resolved various compilation errors, including:
    - `FileNotFoundError: .../nvcc` and `CUDA::nvToolsExt not found` by ensuring correct `torch:nccl` base image.
    - `PyTorch version expected` errors by integrating `use_existing_torch.py` to handle vLLM's PyTorch version expectations.
    - Out-of-memory issues during Flash Attention compilation by setting `MAX_JOBS=16`.
    - Dockerfile Hygiene: Improved `Dockerfile` clarity by consistently uppercasing `AS` keywords.