### PR TITLE
ci(torch): Update `torch:nccl` base images to use NCCL 2.28.3-1

### DIFF
--- a/.github/configurations/torch-nccl.yml
+++ b/.github/configurations/torch-nccl.yml
@@ -5,5 +5,5 @@ include:
   - torch: 2.8.0
     vision: 0.23.0
     audio: 2.8.0
-    nccl: 2.27.7-1
-    nccl-tests-hash: '13b2c72'
+    nccl: 2.28.3-1
+    nccl-tests-hash: '528fb68'


### PR DESCRIPTION
# `torch:nccl` with NCCL 2.28.3-1

This change updates the base images used for the `nccl` flavour of the `ml-containers/torch` and `ml-containers/torch-extras` images to ones that include NCCL 2.28.3-1, up from 2.27.7-1.