### PR TITLE
feat(vllm-tensorizer): Update lmcache to v0.3.7, avoid buggy packages

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -225,7 +225,7 @@ RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
 
 RUN --mount=type=bind,from=flashinfer-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir /tmp/wheels/*.whl -c /tmp/constraints.txt && \
-    python3 -m pip uninstall pynvml && \
+    python3 -m pip uninstall -y pynvml && \
     python3 -m pip install --no-cache-dir nvidia-ml-py
 
 # InfiniStore must be installed before LMCache as LMCache depends on InfiniStore


### PR DESCRIPTION
# `vllm-tensorizer` package updates

This change:

- Updates `lmcache` to v0.3.7,
- Avoids `click` v8.3.0 due to incompatibilities with Python 3.10, and
- Avoids keeping the `pynvml` PyPI package installed, as it is not the correct package for installing `pynvml`, ironically
  - `pynvml` was installed automatically as a dependency of `flashinfer` until a later version that we are not currently bundling