### PR TITLE
build(vllm-tensorizer): Bump vllm to v0.19.1, pin transformers 5.5.4 + nixl 1.0.0

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,5 +1,5 @@
 vllm-commit:
-  - 'v0.19.0'
+  - 'v0.19.1'
 flashinfer-commit:
   - 'v0.6.6'
 lmcache-commit:

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -293,8 +293,19 @@ ARG TARGETPLATFORM
 # Ray was removed as a default dependancy by vllm in v18, but it is still required
 # for the multi-node setup.
 
-# Gemma 4 needs transformers > 5.5.0, but is packaged with 4 in vllm 19.
-# We must explicitly update it until vLLM updates their dependency.
+# Pin transformers to 5.5.4: satisfies both Gemma 4 (needs > 5.5.0) and
+# Kimi K2.5 (HF PR #45359 landed in 5.5.4 restores the custom slow
+# TikTokenTokenizer path with sparse added_tokens_decoder IDs — earlier
+# 5.x versions dense-pack them and scramble tool-call output). vLLM
+# 0.19.1's common.txt declares `transformers >= 4.56.0, != 5.5.0`, so
+# 5.5.4 is in-spec.
+#
+# Pin nixl and nixl-cu12 to 1.0.0: nixl-cu12 1.0.1 bundles a different
+# libucs.so with a static-destructor ordering bug in ucs_topo_release_devices
+# that SIGSEGVs during Python interpreter shutdown (atexit), causing
+# vLLM's model-registry subprocess to return non-zero even though the
+# inspection work completes. 1.0.0's bundled libucs.so does not have
+# this bug. Drop this pin once nixl ships a fixed release.
 
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       BITSANDBYTES_VER='0.42.0'; \
@@ -303,7 +314,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     fi && \
     python3 -m pip install --no-cache-dir \
       accelerate hf_transfer 'modelscope!=1.15.0' "bitsandbytes>=${BITSANDBYTES_VER:?}" 'timm>=1.0.17' \
-      'runai-model-streamer[s3,gcs]>=0.15.3' "ray[cgraph]>=2.48.0" "transformers>=5.5.0" -c /tmp/constraints.txt && \
+      'runai-model-streamer[s3,gcs]>=0.15.3' "ray[cgraph]>=2.48.0" \
+      'transformers==5.5.4' 'nixl==1.0.0' 'nixl-cu12==1.0.0' \
+      -c /tmp/constraints.txt && \
     rm /tmp/constraints.txt
 
 EXPOSE 8080

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -293,19 +293,9 @@ ARG TARGETPLATFORM
 # Ray was removed as a default dependancy by vllm in v18, but it is still required
 # for the multi-node setup.
 
-# Pin transformers to 5.5.4: satisfies both Gemma 4 (needs > 5.5.0) and
-# Kimi K2.5 (HF PR #45359 landed in 5.5.4 restores the custom slow
-# TikTokenTokenizer path with sparse added_tokens_decoder IDs — earlier
-# 5.x versions dense-pack them and scramble tool-call output). vLLM
-# 0.19.1's common.txt declares `transformers >= 4.56.0, != 5.5.0`, so
-# 5.5.4 is in-spec.
-#
-# Pin nixl and nixl-cu12 to 1.0.0: nixl-cu12 1.0.1 bundles a different
-# libucs.so with a static-destructor ordering bug in ucs_topo_release_devices
-# that SIGSEGVs during Python interpreter shutdown (atexit), causing
-# vLLM's model-registry subprocess to return non-zero even though the
-# inspection work completes. 1.0.0's bundled libucs.so does not have
-# this bug. Drop this pin once nixl ships a fixed release.
+# * Gemma 4 needs transformers > 5.5.0
+# * Kimi K2.5 tool-call scramble fixed in transformers 5.5.4 (huggingface/transformers#45359)
+# * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 — pin both to 1.0.0
 
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       BITSANDBYTES_VER='0.42.0'; \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -295,7 +295,7 @@ ARG TARGETPLATFORM
 
 # * Gemma 4 needs transformers > 5.5.0
 # * Kimi K2.5 tool-call scramble fixed in transformers 5.5.4 (huggingface/transformers#45359)
-# * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 — pin both to 1.0.0
+# * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 (vllm-project/vllm#40642) — pin both to 1.0.0
 
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       BITSANDBYTES_VER='0.42.0'; \


### PR DESCRIPTION
## Summary
  - Bump `vllm-commit` to `v0.19.1`
  - Pin `transformers==5.5.4` — contains [huggingface/transformers#45359](https://github.com/huggingface/transformers/pull/45359) (restores Kimi K2.5 slow
  tokenizer); still `>5.5.0` for Gemma 4
  - Pin `nixl==1.0.0 nixl-cu12==1.0.0` — `1.0.1` ships a `libucs.so` with a `ucs_topo_release_devices()` destructor bug

  ## Context
  nixl-cu12 1.0.1 SIGSEGVs during Python interpreter shutdown on GB200. vLLM's model-registry subprocess checks `returncode` before reading its pickled output, so
  the shutdown crash surfaces as `pydantic ValidationError: Model architectures ['KimiK25ForConditionalGeneration'] failed to be inspected` — even though the
  inspection work itself completed. Drop the nixl pins once a fixed nixl release lands.

  Earlier 5.x transformers (5.4–5.5.3) dense-pack Kimi's `added_tokens_decoder` IDs, shifting every tool-call marker by −2/−3 and scrambling tool-call output.
  5.5.4 is the first version with the upstream fix.

  ## Test plan


  ## Test plan
  - [x] GB200 dev (TP=4): pod 1/1 Running; 15/15 Kimi K2.5 functional tests PASS (tokenizer sparse IDs, tool-call streaming/parallel/multi-turn/forced-choice,
  reasoning, legacy completions)
  - [x] 2×2 factorial: `v0.19.1` no-pin → CrashLoop; `v0.19.1` +pin → Works

  Ref: INF-353