### PR TITLE
ci(torch): Update to CUDA 13.2.1 and NCCL v2.30.4-1

### DIFF
--- a/.github/configurations/torch-base.yml
+++ b/.github/configurations/torch-base.yml
@@ -1,4 +1,4 @@
-cuda: [ 12.9.1, 13.2.0 ]
+cuda: [ 12.9.1, 13.2.1 ]
 os: [ ubuntu22.04, ubuntu24.04 ]
 abi: [ 1 ]
 include:

--- a/.github/configurations/torch-nccl.yml
+++ b/.github/configurations/torch-nccl.yml
@@ -5,5 +5,5 @@ include:
   - torch: 2.11.0
     vision: 0.26.0
     audio: 2.11.0
-    nccl: 2.29.7-1
-    nccl-tests-hash: '7112046'
+    nccl: 2.30.3-1
+    nccl-tests-hash: '49210fb'

--- a/.github/configurations/torch-nccl.yml
+++ b/.github/configurations/torch-nccl.yml
@@ -1,9 +1,9 @@
-cuda: [ 12.9.1, 13.2.0 ]
+cuda: [ 12.9.1, 13.2.1 ]
 os: [ ubuntu22.04, ubuntu24.04 ]
 abi: [ 1 ]
 include:
   - torch: 2.11.0
     vision: 0.26.0
     audio: 2.11.0
-    nccl: 2.30.3-1
-    nccl-tests-hash: '49210fb'
+    nccl: 2.30.4-1
+    nccl-tests-hash: '111c25a'


### PR DESCRIPTION
# CUDA 13.2.1 & NCCL 2.30.4-1

This change updates the CUDA 13.2 builds from 13.2.0 to 13.2.1, and updates the `torch:nccl`-flavour images to new bases with NCCL [2.30.4-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.4-1).