### PR TITLE
feat(vllm-tensorizer): Bump vLLM to v0.20.0 on CUDA 12.9

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,7 +1,7 @@
 vllm-commit:
-  - 'v0.19.1'
+  - 'v0.20.0'
 flashinfer-commit:
-  - 'v0.6.6'
+  - 'v0.6.8'
 lmcache-commit:
   - 'v0.4.2'
 builder-base-image:

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -5,6 +5,6 @@ flashinfer-commit:
 lmcache-commit:
   - 'v0.4.2'
 builder-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
 final-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -5,6 +5,6 @@ flashinfer-commit:
 lmcache-commit:
   - 'v0.4.2'
 builder-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:1a21fa8-nccl-cuda12.9.1-ubuntu22.04-nccl2.29.7-1-torch2.10.0-vision0.25.0-audio2.10.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
 final-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:1a21fa8-nccl-cuda12.9.1-ubuntu22.04-nccl2.29.7-1-torch2.10.0-vision0.25.0-audio2.10.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -160,10 +160,10 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
     [ -n "${CUDA_VERSION}" ] && \
     python3 -m pip install --no-cache-dir \
       requests nvidia-ml-py ninja tqdm filelock \
-      'nvidia-cudnn-frontend>=1.13.0' \
+      'nvidia-cudnn-frontend>=1.13.0,<1.19.0' \
       "cuda-python~=${CUDA_VERSION}" \
       "nvidia-nvshmem-cu${CUDA_VERSION%%.*}<3.6" \
-      'apache-tvm-ffi>=0.1,<0.2' && \
+      'apache-tvm-ffi==0.1.9' && \
     export FLASHINFER_LOCAL_VERSION="$(sed -E 's@([[:digit:]]+)\.([[:digit:]]+).*$@cu\1\2@')" \
       FLASHINFER_AOT_USE_PY_LIMITED_API='0' \
       FLASHINFER_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -113,7 +113,7 @@ RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
 
 FROM alpine/git:2.36.3 AS deepgemm-downloader
 WORKDIR /git
-ARG DEEPGEMM_COMMIT='477618cd51baffca09c4b0b87e97c03fe827ef03'
+ARG DEEPGEMM_COMMIT='891d57b4db1071624b5c8fa0d1e51cb317fa709f'
 RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
       https://github.com/deepseek-ai/DeepGEMM && \
     cd DeepGEMM && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -22,7 +22,7 @@ RUN ldconfig
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
-      python3-pip git ninja-build cmake && \
+      python3-pip git ninja-build cmake gcc-12 g++-12 && \
     apt-get clean && \
     pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' wheel setuptools_scm regex build
 
@@ -167,10 +167,11 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
     export FLASHINFER_LOCAL_VERSION="$(sed -E 's@([[:digit:]]+)\.([[:digit:]]+).*$@cu\1\2@')" \
       FLASHINFER_AOT_USE_PY_LIMITED_API='0' \
       FLASHINFER_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" && \
-    for DIR in . flashinfer-cubin flashinfer-jit-cache; do ( \
+    for DIR in . flashinfer-cubin; do ( \
       cd "${DIR}" && \
       /opt/build.sh; \
-    ); done
+    ); done && \
+    ( cd flashinfer-jit-cache && CXX_WRAPPED=g++-12 CC_WRAPPED=gcc-12 /opt/build.sh )
 
 WORKDIR /wheels
 


### PR DESCRIPTION
## Summary

  - Bumps vLLM to v0.20.0, flashinfer to v0.6.8, torch base image to 2.11.0 (CUDA 12.9, Ubuntu 22.04)
  - Bumps DeepGEMM to `891d57b`
  - Pins `nvidia-cudnn-frontend<1.19.0` and `apache-tvm-ffi==0.1.9` to avoid breaking changes in newer releases
  - Fixes flashinfer-jit-cache build failure: the TRTLLM GEMM headers bundled with flashinfer v0.6.8 require GCC 12+; routes just the jit-cache compilation through `g++-12` via `CXX_WRAPPED`/`CC_WRAPPED` while
  keeping GCC 11 for all other packages

Note: working on CUDA 13.2 version; releasing this to unblock people for now