### PR TITLE
build(vllm-tensorizer): add sm103 arch support

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -49,20 +49,20 @@ ENV CC=/opt/sccache-cc.sh \
 ENV TORCH_EXTENSION_SKIP_NVCC_GEN_DEPENDENCIES=1
 
 ARG TARGETPLATFORM
-# Switch 9.0, 10.0, and 12.0 to -a variants; preserve originals for PTX
+# Switch 9.x, 10.x, and 12.x to -a variants; inject 10.3a if absent.
 # Flashinfer v0.28.0 in particular can only build for 12.0a but not 12.0
 # vLLM Marlin MoE requires 8.0+PTX for non-FP8 WNA16 kernels. Keep the arm64
 # filter strict about unsupported sm80 SASS, but preserve compute80 PTX so
 # newer architectures can forward-JIT the generated sm80 kernels.
 RUN printf 'TORCH_CUDA_ARCH_LIST=' && \
     echo "${TORCH_CUDA_ARCH_LIST}" \
-    | sed -E 's@\b(9|10|12)\.0\b@\1\.0a@g; s@\+PTX\b@@g' \
+    | sed -E 's@\b(9|10|12)\.([0-9]+)\b@\1.\2a@g; /\b10\.3a\b/!s@\b10\.0a\b@10.0a 10.3a@; s@\+PTX\b@@g' \
     | tee /opt/arch_list.txt && \
     printf 'NVCC_WRAPPER_FILTER_CODES=' && \
     if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-      echo 'sm_80;sm_89;sm_90;sm_100;sm_120;compute_89;compute_90;compute_100;compute_120'; \
+      echo 'sm_80;sm_89;sm_90;sm_100;sm_103;sm_120;compute_89;compute_90;compute_100;compute_103;compute_120'; \
     else \
-      echo 'sm_90;sm_100;sm_120;compute_90;compute_100;compute_120'; \
+      echo 'sm_90;sm_100;sm_103;sm_120;compute_90;compute_100;compute_103;compute_120'; \
     fi \
     | tee /opt/filter_codes.txt && \
     printf '#!/bin/sh\nexport %s %s;\n' \


### PR DESCRIPTION
## Summary
- add `10.3a` to the vLLM tensorizer extension arch list derived from the Torch base image
- convert existing `9.x`, `10.x`, and `12.x` arch entries to `a` variants before conditionally injecting `10.3a`
- filter plain `sm_103` / `compute_103` in the nvcc wrapper denylist while preserving `sm_103a` / `compute_103a`

## Context
GB300/B300 are compute capability 10.3. vLLM v0.20.0 and FlashInfer v0.6.8 already have 10.3/10.3a support paths; this change makes the ml-containers vLLM tensorizer build include the 10.3a target.

The `sm_103` / `compute_103` additions are denylist entries for unsupported plain 10.3 outputs. They intentionally do not filter `sm_103a` / `compute_103a`, which are the architecture-specific outputs this PR is adding.

## Validation
- `git diff --check`
- validated the GNU sed arch transform with `gsed`:
  - current base list `8.0 8.9 9.0 10.0 12.0+PTX` -> `8.0 8.9 9.0a 10.0a 10.3a 12.0a`
  - future base list containing `10.3` -> `8.0 8.9 9.0a 10.0a 10.3a 12.0a`
  - future base list already containing `10.3a` -> `8.0 8.9 9.0a 10.0a 10.3a 12.0a`
  - reviewer case `10.0 10.3` -> `10.0a 10.3a`
- GitHub Actions succeeded for the current PR head:
  - run: https://github.com/coreweave/ml-containers/actions/runs/25601638350
  - `Build (amd64)`: success
  - `Build (arm64)`: success
  - `Merge Manifests`: success
- Built image for this PR head:
  - `ghcr.io/coreweave/ml-containers/vllm-tensorizer:abatilo-vllm-sm103-9526aee-v0.20.0`
- Manual image validation: tested the final image and it looks good.