### PR TITLE
feat(vllm-tensorizer): Bump vLLM to v0.20.2 on CUDA 13.2 / Ubuntu 24.04

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -5,6 +5,6 @@ flashinfer-commit:
 lmcache-commit:
   - 'v0.4.2'
 builder-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
 final-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,10 +1,13 @@
-vllm-commit:
-  - 'v0.20.2'
-flashinfer-commit:
-  - 'v0.6.8'
-lmcache-commit:
-  - 'v0.4.2'
-builder-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
-final-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+include:
+  - vllm-commit: 'v0.20.2'
+    flashinfer-commit: 'v0.6.8'
+    lmcache-commit: 'v0.4.2'
+    builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+    final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+    tag-suffix: 'v0.20.2-cuda13.2.1-ubuntu24.04'
+  - vllm-commit: 'v0.20.2'
+    flashinfer-commit: 'v0.6.8'
+    lmcache-commit: 'v0.4.2'
+    builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+    final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+    tag-suffix: 'v0.20.2-cuda12.9.1-ubuntu24.04'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -5,6 +5,6 @@ flashinfer-commit:
 lmcache-commit:
   - 'v0.4.2'
 builder-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
 final-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu22.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  - 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,5 +1,5 @@
 vllm-commit:
-  - 'v0.20.0'
+  - 'v0.20.2'
 flashinfer-commit:
   - 'v0.6.8'
 lmcache-commit:

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
-      tag-suffix: ${{ matrix.vllm-commit }}
+      tag-suffix: ${{ matrix.tag-suffix }}
       build-contexts: |
         common=common
       object-storage-secrets: true

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -164,7 +164,7 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
     python3 -m pip install --no-cache-dir \
       requests nvidia-ml-py ninja tqdm filelock \
       'nvidia-cudnn-frontend>=1.13.0,<1.19.0' \
-      "cuda-python~=${CUDA_VERSION}" \
+      "cuda-python~=${CUDA_VERSION%.*}" \
       "nvidia-nvshmem-cu${CUDA_VERSION%%.*}<3.6" \
       'apache-tvm-ffi==0.1.9' && \
     export FLASHINFER_LOCAL_VERSION="$(sed -E 's@([[:digit:]]+)\.([[:digit:]]+).*$@cu\1\2@')" \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -22,9 +22,10 @@ RUN ldconfig
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
-      python3-pip git ninja-build cmake gcc-12 g++-12 && \
+      git ninja-build cmake gcc-12 g++-12 && \
     apt-get clean && \
-    pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' wheel setuptools_scm regex build
+    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED && \
+    pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' setuptools_scm regex build
 
 # Create the /wheels directory
 WORKDIR /wheels

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -191,7 +191,8 @@ RUN --mount=type=bind,from=lmcache-downloader,source=/git/LMCache,target=/worksp
     . /opt/arch_flags.sh && \
     python3 -m pip install --no-cache-dir \
     'setuptools>=77.0.3,<81.0.0' \
-    'setuptools_scm>=8' && \
+    'setuptools_scm>=8' \
+    'wheel' && \
     sed -Ei \
       '/[ "]*(torch(vision|audio)?|xformers) *[<>=~]+/d' \
     pyproject.toml requirements/*.txt && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -265,7 +265,8 @@ FROM ${FINAL_BASE_IMAGE} AS base
 
 WORKDIR /workspace
 
-RUN apt-get -qq update && apt-get install -y --no-install-recommends curl libsodium23 libnuma-dev && apt-get clean
+RUN apt-get -qq update && apt-get install -y --no-install-recommends curl libsodium23 libnuma-dev && apt-get clean && \
+    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
 
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
       git ninja-build cmake gcc-12 g++-12 && \
     apt-get clean && \
-    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED && \
-    pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' wheel setuptools_scm regex build
+    rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED && \
+    python3 -m pip install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' wheel setuptools_scm regex build
 
 # Create the /wheels directory
 WORKDIR /wheels
@@ -269,7 +269,7 @@ RUN apt-get -qq update && \
     apt-get install -y --no-install-recommends curl libsodium23 libnuma-dev && \
     apt-get purge -y python3-jwt && \
     apt-get clean && \
-    rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
+    rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
 
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt && \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.10
-ARG BUILDER_BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch:17ad6db-nccl-cuda12.9.1-ubuntu22.04-nccl2.29.2-1-torch2.10.0-vision0.25.0-audio2.10.0-abi1"
-ARG FINAL_BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch:17ad6db-nccl-cuda12.9.1-ubuntu22.04-nccl2.29.2-1-torch2.10.0-vision0.25.0-audio2.10.0-abi1"
+ARG BUILDER_BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1"
+ARG FINAL_BASE_IMAGE="ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1"
 ARG SCCACHE_VERSION="0.14.0"
 
 FROM alpine/curl:8.17.0 AS sccache-downloader

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -265,7 +265,10 @@ FROM ${FINAL_BASE_IMAGE} AS base
 
 WORKDIR /workspace
 
-RUN apt-get -qq update && apt-get install -y --no-install-recommends curl libsodium23 libnuma-dev && apt-get clean && \
+RUN apt-get -qq update && \
+    apt-get install -y --no-install-recommends curl libsodium23 libnuma-dev && \
+    apt-get purge -y python3-jwt && \
+    apt-get clean && \
     rm -f /usr/lib/python3*/EXTERNALLY-MANAGED
 
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get -qq update && \
       git ninja-build cmake gcc-12 g++-12 && \
     apt-get clean && \
     rm -f /usr/lib/python3*/EXTERNALLY-MANAGED && \
-    pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' setuptools_scm regex build
+    pip3 install -U --no-cache-dir pip packaging 'setuptools>=77.0.3,<81.0.0' wheel setuptools_scm regex build
 
 # Create the /wheels directory
 WORKDIR /wheels
@@ -191,8 +191,7 @@ RUN --mount=type=bind,from=lmcache-downloader,source=/git/LMCache,target=/worksp
     . /opt/arch_flags.sh && \
     python3 -m pip install --no-cache-dir \
     'setuptools>=77.0.3,<81.0.0' \
-    'setuptools_scm>=8' \
-    'wheel' && \
+    'setuptools_scm>=8' && \
     sed -Ei \
       '/[ "]*(torch(vision|audio)?|xformers) *[<>=~]+/d' \
     pyproject.toml requirements/*.txt && \


### PR DESCRIPTION
## Summary

  - Bump vLLM to v0.20.2
  - Add a build matrix producing two variants, both on Ubuntu 24.04 / torch 2.11.0:
    - `v0.20.2-cuda13.2.1-ubuntu24.04`
    - `v0.20.2-cuda12.9.1-ubuntu24.04`

  ## Ubuntu 24.04 compatibility fixes

  - Remove `python3-pip` from apt in `builder-base` and add `rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED` before pip bootstrap — on Ubuntu 24.04, apt-installed pip has no RECORD file and blocks pip self-upgrade
  - Purge `python3-jwt` in the final `base` stage before pip installs — same root cause: Debian-managed PyJWT has no RECORD file and blocks vLLM's dependency resolution
  - Fix `cuda-python` version spec from `~=${CUDA_VERSION}` to `~=${CUDA_VERSION%.*}` — patch-level CUDA versions (e.g. `13.2.1`) don't match available cuda-python releases; strip to major.minor
  - Install `wheel` package in `lmcache-builder` and restore it to `builder-base` pip install

Relevant information: https://github.com/vllm-project/vllm/pull/35386/changes/6c964bd0e4ed91594fa627a48200b22907856770