### PR TITLE
feat(vllm-tensorizer): Upgrade to vLLM v0.21.0

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,11 +1,11 @@
 include:
-  - vllm-commit: 'v0.20.2'
+  - vllm-commit: 'v0.21.0'
     flashinfer-commit: 'v0.6.8'
     lmcache-commit: 'v0.4.2'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     tag-suffix: 'v0.20.2-cuda13.2.1-ubuntu24.04'
-  - vllm-commit: 'v0.20.2'
+  - vllm-commit: 'v0.21.0'
     flashinfer-commit: 'v0.6.8'
     lmcache-commit: 'v0.4.2'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'


### PR DESCRIPTION
Upgrades to vLLM v0.21.0.
No upstream flashinfer or lmcache bumps upstream here.