### PR TITLE
ci(vllm-tensorizer): Separate BuildKit cache slots per matrix variant

### DIFF
--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -30,6 +30,7 @@ jobs:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
       tag-suffix: ${{ matrix.tag-suffix }}
+      cache-key: ${{ matrix.tag-suffix }}
       build-contexts: |
         common=common
       object-storage-secrets: true

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -18,6 +18,10 @@ jobs:
             .["vllm-commit"] + "-" +
             (.["builder-base-image"] | match("cuda[0-9.]+").string) + "-" +
             (.["builder-base-image"] | match("ubuntu[0-9.]+").string)
+          ),
+          "cache-key": (
+            (.["builder-base-image"] | match("cuda[0-9.]+").string) + "-" +
+            (.["builder-base-image"] | match("ubuntu[0-9.]+").string)
           )
         })
   build:
@@ -30,7 +34,7 @@ jobs:
       image-name: vllm-tensorizer
       folder: vllm-tensorizer
       tag-suffix: ${{ matrix.tag-suffix }}
-      cache-key: ${{ matrix.tag-suffix }}
+      cache-key: ${{ matrix.cache-key }}
       build-contexts: |
         common=common
       object-storage-secrets: true


### PR DESCRIPTION
## Summary

  Pass `cache-key: ${{ matrix.tag-suffix }}` to the build workflow so each cuda variant of the `vllm-tensorizer` matrix gets its own BuildKit registry cache slot, instead of fighting over a single shared one.

  ## The problem

  Observed in [build](https://github.com/coreweave/ml-containers/actions/runs/26060641736/job/76619707891): the cuda13.2 variant builds in ~3 min while cuda12.9 builds take ~2 hours, even after multiple commits in-PR and with sccache reporting **100% hit rate** on cuda12.9.

  Root cause: `build.yml` computes the BuildKit registry cache reference as `${arch}-${image-name}[-${cache-key}]`. We weren't passing `cache-key`, so both matrix variants pushed to and pulled from the same slot: `amd64-vllm-tensorizer`.

  Each matrix run, both variants pulled the most recently pushed cache. That cache's `builder-base` layer was built `FROM` the *other* cuda's base image, so the digest didn't match and BuildKit had to rebuild every layer from scratch. Once nvcc was invoked, sccache found everything in S3 (hence the 100% hit rate) — but fetching tens of thousands of `.o` files one-by-one from S3 still takes hours. 

  ## The fix

  ```yaml
  cache-key: ${{ matrix.tag-suffix }}

  Yields per-variant cache refs:
  - ${registry}/buildcache:amd64-vllm-tensorizer-v0.21.0-cuda13.2.1-ubuntu24.04
  - ${registry}/buildcache:amd64-vllm-tensorizer-v0.21.0-cuda12.9.1-ubuntu24.04

  After merge, the first cuda12.9 build is still slow (cold BuildKit slot), but subsequent commits that don't touch the builder stages will hit the per-variant slot and finish in minutes like cuda13.2 does today.