### PR TITLE
build(vllm-tensorizer): Bump `transformers` to 5.9.0 for Gemma 4 MTP

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -329,7 +329,7 @@ ARG TARGETPLATFORM
 # Ray was removed as a default dependancy by vllm in v18, but it is still required
 # for the multi-node setup.
 
-# * Gemma 4 needs transformers > 5.5.0
+# * Gemma 4 MTP needs transformers 5.9.0
 # * Kimi K2.5 tool-call scramble fixed in transformers 5.5.4 (huggingface/transformers#45359)
 # * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 (vllm-project/vllm#40642) — pin both to 1.0.0
 # * llguidance bumped to 1.7 — vLLM's pin (<1.4) lacks JSON Schema "format": "uri" support
@@ -343,7 +343,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     python3 -m pip install --no-cache-dir \
       accelerate hf_transfer 'modelscope!=1.15.0' "bitsandbytes>=${BITSANDBYTES_VER:?}" 'timm>=1.0.17' \
       'runai-model-streamer[s3,gcs]>=0.15.3' "ray[cgraph]>=2.48.0" \
-      'transformers==5.5.4' 'nixl==1.0.0' 'nixl-cu12==1.0.0' \
+      'transformers==5.9.0' 'nixl==1.0.0' 'nixl-cu12==1.0.0' \
       'llguidance>=1.7.0,<1.8.0' \
       -c /tmp/constraints.txt && \
     rm /tmp/constraints.txt


### PR DESCRIPTION
Gemma 4 MTP (Multi-Token Prediction) support requires transformers
5.9.0. The pin was previously 5.5.4, set for Gemma 4 (>5.5.0) and a
Kimi K2.5 tool-call fix that landed in 5.5.4. Bumping to 5.9.0 satisfies
the new MTP requirement and still includes the Kimi K2.5 fix, so the
existing comment for that pin is preserved.

The generated constraints file only bounds torch-family packages plus
click, so it imposes no competing constraint on transformers.
