### PR TITLE
feat(vllm): Use exact commit for vLLM

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,10 +1,10 @@
 include:
-  - vllm-commit: 'v0.24.0'
+  - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
     flashinfer-commit: 'v0.6.12'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
-  - vllm-commit: 'v0.24.0'
+  - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
     flashinfer-commit: 'v0.6.12'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'


### PR DESCRIPTION
Uses the exact upstream commit for vLLM build. Also update to newest version of v0.24.0 (prerelease v0.24.0 got added on to).