### PR TITLE
fix(vllm): build FlashInfer 0.6.14 with GLM routing fix

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,11 +1,11 @@
 include:
   - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
-    flashinfer-commit: 'v0.6.12'
+    flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
   - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
-    flashinfer-commit: 'v0.6.12'
+    flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -97,6 +97,9 @@ RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
     git checkout "${FLASHINFER_COMMIT}" && \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=tree:0
+COPY flashinfer-v0.6.14-deepseekv3-no-group-routing.patch /git/patch
+RUN git -C flashinfer apply -v --stat --apply /git/patch && \
+    rm /git/patch
 
 
 FROM alpine/git:2.36.3 AS lmcache-downloader
@@ -198,11 +201,16 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
     . /opt/arch_flags.sh && \
     export TORCH_CUDA_ARCH_LIST="$(echo "${TORCH_CUDA_ARCH_LIST}" | sed 's@[67]\.0 \+@@g')" && \
     [ -n "${CUDA_VERSION}" ] && \
+    CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl==4.5.2' && \
+    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+      CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl[cu13]==4.5.2'; \
+    fi && \
     python3 -m pip install --no-cache-dir \
       requests nvidia-ml-py ninja tqdm filelock \
       'nvidia-cudnn-frontend>=1.19.1' \
       "cuda-python~=${CUDA_VERSION%.*}" \
       "nvidia-nvshmem-cu${CUDA_VERSION%%.*}<3.6" \
+      "${CUTLASS_DSL_PACKAGE}" \
       'apache-tvm-ffi==0.1.9' && \
     export FLASHINFER_LOCAL_VERSION="$(sed -E 's@([[:digit:]]+)\.([[:digit:]]+).*$@cu\1\2@')" \
       FLASHINFER_AOT_USE_PY_LIMITED_API='0' \

--- a/vllm-tensorizer/flashinfer-v0.6.14-deepseekv3-no-group-routing.patch
+++ b/vllm-tensorizer/flashinfer-v0.6.14-deepseekv3-no-group-routing.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ace Eldeib <aeldeib@coreweave.com>
+Date: Thu, 2 Jul 2026 01:10:00 -0400
+Subject: [PATCH] Fix FlashInfer TRTLLM DeepSeek no-group routing weights
+
+GLM-5.2 uses FlashInfer TRTLLM NvFP4 MoE through the DeepSeekV3 no-group
+routing path. That path selects experts with `sigmoid(router_logit) +
+routing_bias`, then normalizes the selected experts with the unbiased sigmoid
+scores.
+
+The block-per-token routing kernel already preserves that separation: it writes
+the biased selection key to shared memory and writes the unbiased sigmoid into
+an auxiliary shared-memory array consumed by `ScaledSumNormalizePostprocess`.
+The warp-per-token routing path did not. It selected top-k using the biased
+score, then tried to recover the unbiased sigmoid as `selected_score - bias`.
+
+That reconstruction is lossy for GLM-5.2. The model can produce tiny sigmoid
+scores around 1e-8 to 1e-7 with routing correction biases around 12. In fp32,
+adding the tiny sigmoid to the large bias rounds back to the bias, so
+subtracting the bias later yields zero. When every selected expert in a row
+collapses that way, `ScaledSumNormalizePostprocess` computes `0 / 0`, produces
+NaN expert weights, and GLM decode can collapse into repeated punctuation.
+
+Keep expert selection unchanged, but recompute the selected experts' unbiased
+sigmoid scores from the original logits before the warp-path normalization.
+This matches the existing block-per-token auxiliary path and the Python routing
+reference: selection uses `sigmoid + bias`; final weights use `sigmoid`.
+
+Also set the same denominator epsilon already used by the adjacent MiniMax2
+path. The epsilon is only a final guard; the main correctness fix is preserving
+the unbiased sigmoid for normalization.
+
+Signed-off-by: Ace Eldeib <aeldeib@coreweave.com>
+---
+ .../trtllm/fused_moe/RoutingCustomPolicy.cuh | 30 +++++++++++++++++--
+ csrc/trtllm_fused_moe_runner.cu              |  1 +
+ 2 files changed, 29 insertions(+), 2 deletions(-)
+
+diff --git a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+index 934dcbf71..5f1f6a6ae 100644
+--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
++++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+@@ -434,6 +434,24 @@ struct ScaledSumNormalizePostprocess {
+     }
+   }
+ 
++  template <typename DataType, typename InputType, int K, typename ParamsT>
++  __forceinline__ __device__ static void applyWithScores(
++      cg::thread_block_tile<WarpSize> const& warp, DataType (&warpTopKScore)[K],
++      int32_t const (&warpTopKExpertIdx)[K], int32_t laneIdx, int32_t topK,
++      InputType const* ptrScores, ParamsT const& params) {
++    float sigmoidScore = 0.f;
++    if (laneIdx < topK) {
++      int32_t const expertIdx = warpTopKExpertIdx[laneIdx];
++      sigmoidScore = sigmoid_accurate(static_cast<float>(ptrScores[expertIdx]));
++    }
++
++    float sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
++    if (laneIdx < topK) {
++      warpTopKScore[laneIdx] =
++          static_cast<DataType>(sigmoidScore * params.routeScale / (sum + params.sumEpsilon));
++    }
++  }
++
+   /// Block-per-token variant: read un-biased sigmoid directly from smemAux
+   /// (written by SigmoidBiasPreprocess::applyToSmem) instead of reloading bias
+   /// and subtracting.  Saves one global memory read + one FMA per top-K lane.
+@@ -566,8 +584,14 @@ struct TopKExpertSelect {
+     topk::reduceTopK(warp, warpTopKScore, warpTopKExpertIdx, score, idx, minScore, topK);
+ 
+     // Apply postprocess (e.g. renormalize, softmax over top-K, scaled renormalize, ...)
+-    PostprocessPolicy_::apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK,
+-                              params.mExpertSelectParams.mPostprocessParams);
++    if constexpr (std::is_same_v<PostprocessPolicy_, ScaledSumNormalizePostprocess>) {
++      PostprocessPolicy_::template applyWithScores<DataType, InputType, K>(
++          warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK, ptrScores,
++          params.mExpertSelectParams.mPostprocessParams);
++    } else {
++      PostprocessPolicy_::apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK,
++                                params.mExpertSelectParams.mPostprocessParams);
++    }
+   }
+ };
+ 
+diff --git a/csrc/trtllm_fused_moe_runner.cu b/csrc/trtllm_fused_moe_runner.cu
+index 6e7c97395..f2d949d51 100644
+--- a/csrc/trtllm_fused_moe_runner.cu
++++ b/csrc/trtllm_fused_moe_runner.cu
+@@ -76,6 +76,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
+     routingData.mPtrRoutingBias = routingBias;
+     routingData.mDtypeBias = dtypeBias;
+     routingData.mRouteScale = routedScalingFactor;
++    routingData.mSumEpsilon = 1e-20f;
+ 
+     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+     routingData.mPtrTopKIds = expertIds;
+-- 
+2.50.0


### PR DESCRIPTION
Build vllm-tensorizer from FlashInfer v0.6.14 so the image includes the upstream SM100 TopK fixes needed by the FlashInfer TRTLLM MoE path.

FlashInfer v0.6.14 requires the CUDA-specific nvidia-cutlass-dsl extra on CUDA 13, so align the build dependency before compiling FlashInfer packages and cached kernels.

Apply the local DeepSeekV3 no-group routing source patch during the FlashInfer checkout stage. The patch preserves biased sigmoid scores for top-k selection while normalizing final GLM-5.2 expert weights from unbiased sigmoid(logit), avoiding the fp32 cancellation that can turn tiny selected sigmoid scores into zero after subtracting large routing bias.

Applying the patch before the existing FlashInfer build stage keeps flashinfer-python, flashinfer-cubin, and flashinfer-jit-cache built from one source tree, so infr images do not need post-install FlashInfer source edits.

Validation: patch applies cleanly to FlashInfer v0.6.14; the same source change passed GLM-5.2 B200 diagnostic quality and high-KV liveness gates after rebuilding the TRTLLM JIT object.