### PR TITLE
feat(vllm): Upgrade to vLLM v0.25.0

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,10 +1,10 @@
 include:
-  - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
+  - vllm-commit: '702f4814fe54fabff350d43cb753ae3e47c0c276'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
-  - vllm-commit: 'ee0da84ab9e04ac7610e28580af62c365e898389'
+  - vllm-commit: '702f4814fe54fabff350d43cb753ae3e47c0c276'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -327,7 +327,7 @@ RUN apt-get -qq update && \
     apt-get purge -y python3-jwt && \
     apt-get clean
 
-# vLLM 0.23 still pins nvidia-cutlass-dsl==4.5.2 (which renamed cutlass.base_dsl.Arch
+# vLLM 0.25 still pins nvidia-cutlass-dsl==4.5.2 (which renamed cutlass.base_dsl.Arch
 # -> arch) but only floors quack-kernels (>=0.3.3). A drifted quack still imports
 # the old `Arch` and crashes DeepSeek-V4's cute-DSL indexer at load. cutlass-dsl is
 # unchanged from 0.22.0, so keep quack pinned to the same known-good 0.4.1 release.
@@ -371,8 +371,8 @@ ARG TARGETPLATFORM
 # * Kimi K2.5 tool-call scramble fixed in transformers 5.5.4 (huggingface/transformers#45359)
 # * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 (vllm-project/vllm#40642) - verified
 #   no crash on this image with vllm 0.22
-# * llguidance bumped to 1.7 — vLLM's pin (<1.4) lacks JSON Schema "format": "uri" support
-#   (added in llguidance v1.6.0; mirrors upstream vllm-project/vllm#42150)
+# * llguidance pin mirrors vLLM 0.25's own requirement (>=1.7.0,<1.8.0); kept explicit so
+#   JSON Schema "format": "uri" support (llguidance v1.6.0+) can't regress on future bumps
 
 # ray[cgraph]>=2.48.0 will unconditionally install cupy-cuda12x. Uninstall it and install cupy-cuda13x if CUDA major version is 13.
 


### PR DESCRIPTION
## Summary
- Bump `vllm-commit` to `702f4814fe54fabff350d43cb753ae3e47c0c276`, the commit the [v0.25.0](https://github.com/vllm-project/vllm/tree/v0.25.0) tag points at, in both CUDA matrix entries (13.2.1 and 12.9.1).
- Comment-only Dockerfile updates: the quack-kernels==0.4.1 pin was re-verified against 0.25 (upstream still pins nvidia-cutlass-dsl==4.5.2 with only a floor on quack-kernels), and the llguidance bullet now reflects that vLLM 0.25 itself requires >=1.7.0,<1.8.0.

## Compatibility verified at the new commit
- torch 2.11.0 / torchvision 0.26.0 / torchaudio 2.11.0 — matches both current base images, no base image change.
- FlashInfer v0.6.14 + GLM routing patch stays ahead of upstream's 0.6.13 pin; patch tag unchanged.
- The CUDA 13 `CUDA_SUPPORTED_ARCHS` list still lacks 10.3, so the CMakeLists sed patch (and its grep guard) still applies.
- Rust build inputs unchanged: toolchain channel 1.95, `build_rust.sh` artifacts still `vllm/vllm-rs` + `vllm/_rust_*.so`, `tools/install_protoc.sh` present.

## Risk
v0.25 adds new runtime deps installed from PyPI in the final stage (tilelang, humming-kernels, PyNvVideoCodec==2.0.4, tokenspeed-mla, torchcodec, numba 0.65, fastsafetensors); if any lacks an arm64/cu12 wheel the build will fail at that step — watching CI for this.