### PR TITLE
chore(renovate): semi-automate inference engine updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # Inference specific
+/sglang/ @coreweave/inference
+/.github/configurations/sglang.yml @coreweave/inference
+/.github/workflows/sglang.yml @coreweave/inference
 /vllm-tensorizer/ @coreweave/inference
 /.github/configurations/vllm-tensorizer.yml @coreweave/inference
 /.github/workflows/vllm-tensorizer.yml @coreweave/inference

--- a/.github/configurations/sglang.yml
+++ b/.github/configurations/sglang.yml
@@ -1,6 +1,8 @@
 sglang-commit:
+  # renovate-release: datasource=github-releases depName=sgl-project/sglang currentValue=v0.5.15 versioning=pep440
   - 'f63458b5beaceabbd9d749b9fc956370e1b649e6'
 base-image:
   - 'ghcr.io/coreweave/ml-containers/torch-extras:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
 tag:
+  # renovate-release-tag: datasource=github-releases depName=sgl-project/sglang versioning=pep440
   - 'v0.5.15-cuda13.2.1-torch2.11.0'

--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,9 +1,11 @@
 include:
+  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.25.1 versioning=pep440
   - vllm-commit: '752a3a504485790a2e8491cacbb35c137339ad34'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.25.1 versioning=pep440
   - vllm-commit: '752a3a504485790a2e8491cacbb35c137339ad34'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,40 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>coreweave/renovate-config"],
+
+  // Limit this rollout to the expensive inference runtime builds. Other
+  // dependencies can be enabled deliberately once this flow proves useful.
+  includePaths: [
+    ".github/configurations/sglang.yml",
+    ".github/configurations/vllm-tensorizer.yml",
+  ],
+  enabledManagers: ["custom.regex"],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Track released inference runtimes while retaining immutable commit pins",
+      managerFilePatterns: [
+        "/^\\.github/configurations/(?:sglang|vllm-tensorizer)\\.yml$/",
+      ],
+      matchStrings: [
+        "# renovate-release: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) currentValue=(?<currentValue>\\S+) versioning=(?<versioning>\\S+)\\n[ \\t]*- (?:[a-z-]+: )?'?(?<currentDigest>[0-9a-f]{40})'?",
+        "# renovate-release-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n[ \\t]*- '(?<currentValue>v?[0-9][^'-]*)(?:-[^']*)?'",
+      ],
+    },
+  ],
+
+  packageRules: [
+    {
+      description: "Build released inference updates before requesting review",
+      matchDatasources: ["github-releases"],
+      matchPackageNames: ["sgl-project/sglang", "vllm-project/vllm"],
+      automerge: false,
+      prCreation: "not-pending",
+      labels: ["dependencies", "inference"],
+    },
+  ],
+
+  // Limit total candidate build concurrency across both runtimes.
+  branchConcurrentLimit: 2,
+  prConcurrentLimit: 2,
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,29 +1,68 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Renovate dry run
+name: Renovate
 
 on:
   workflow_dispatch:
     inputs:
-      checkoutRef:
-        description: Git ref containing the Renovate configuration to validate
+      dryRun:
+        description: Dry run
+        default: "true"
         required: true
-        type: string
+        type: choice
+        options:
+          - "false"
+          - "true"
       logLevel:
         description: Log level
-        default: debug
+        default: info
         required: false
         type: string
+  schedule:
+    - cron: "17 * * * *"
+  push:
+    branches: [main]
+    paths:
+      - .github/renovate.json5
+      - .github/workflows/renovate.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   renovate:
-    uses: coreweave/actions/.github/workflows/run-renovate.yml@workflows-v2
-    secrets: inherit
-    with:
-      checkout-ref: ${{ inputs.checkoutRef }}
-      dry-run: "true"
-      log-level: ${{ inputs.logLevel }}
+    runs-on: ubuntu-latest
+    env:
+      LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+      RENOVATE_AUTODISCOVER: true
+      RENOVATE_AUTODISCOVER_FILTER: ${{ github.repository }}
+      RENOVATE_BASE_BRANCH_PATTERNS: ${{ inputs.dryRun == 'true' && format('["{0}"]', github.ref_name) || null }}
+      RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'true' && 'full' || null }}
+      RENOVATE_PLATFORM: github
+      RENOVATE_PLATFORM_COMMIT: enabled
+      RENOVATE_REQUIRE_CONFIG: ${{ inputs.dryRun == 'true' && 'ignored' || null }}
+    steps:
+      - name: Generate Renovate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.ORG_RENOVATE_CLIENTID }}
+          private-key: ${{ secrets.ORG_RENOVATE_PRIVATEKEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            renovate-config
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Renovate
+        uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # 46.1.5
+        with:
+          configurationFile: .github/renovate.json5
+          env-regex: ".*"
+          renovate-version: 43.83.2
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Automate the first step of evaluating new vLLM and SGLang releases while preserving human approval for anything that is not a simple bump.

- Scope Renovate to the two inference configuration files and their two upstream GitHub release feeds.
- Resolve release tags to immutable source SHAs and update both values together.
- Apply the shared seven-day release-age policy, build candidate branches before requesting review, and never automerge.
- Run hourly at minute 17; no-update runs do not trigger image builds.
- Default manual dispatches to dry-run and unattended runs to concise `info` logging.
- Add the existing inference team as CODEOWNERS for SGLang paths.

Validation:

- [Renovate full dry run](https://github.com/coreweave/ml-containers/actions/runs/29853956406): authenticated as `dependa-jr[bot]`, loaded the shared preset, proposed SGLang `v0.5.15.post1` plus commit `0b3bb0cbe31873994c9f989fddfe2f87ca839fdd`, left vLLM at `v0.25.1`, and performed no writes.
- [SGLang build](https://github.com/coreweave/ml-containers/actions/runs/29855149629): passed on the final commit.
- [vLLM-tensorizer build](https://github.com/coreweave/ml-containers/actions/runs/29855149625): passed on the final commit.
