### PR TITLE
feat(vllm): Bump to 0.26.0

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,12 +1,12 @@
 include:
-  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.25.1 versioning=pep440
-  - vllm-commit: '752a3a504485790a2e8491cacbb35c137339ad34'
+  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.26.0 versioning=pep440
+  - vllm-commit: '568afb3a13806beb53bb2e6bd518269357b237c0'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     final-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
-  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.25.1 versioning=pep440
-  - vllm-commit: '752a3a504485790a2e8491cacbb35c137339ad34'
+  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.26.0 versioning=pep440
+  - vllm-commit: '568afb3a13806beb53bb2e6bd518269357b237c0'
     flashinfer-commit: 'v0.6.14'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:bc8c66e-nccl-cuda12.9.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -201,9 +201,9 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
     . /opt/arch_flags.sh && \
     export TORCH_CUDA_ARCH_LIST="$(echo "${TORCH_CUDA_ARCH_LIST}" | sed 's@[67]\.0 \+@@g')" && \
     [ -n "${CUDA_VERSION}" ] && \
-    CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl==4.5.2' && \
+    CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl==4.6.0' && \
     if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-      CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl[cu13]==4.5.2'; \
+      CUTLASS_DSL_PACKAGE='nvidia-cutlass-dsl[cu13]==4.6.0'; \
     fi && \
     python3 -m pip install --no-cache-dir \
       requests nvidia-ml-py ninja tqdm filelock \
@@ -211,7 +211,7 @@ RUN --mount=type=bind,from=flashinfer-downloader,source=/git/flashinfer,target=/
       "cuda-python~=${CUDA_VERSION%.*}" \
       "nvidia-nvshmem-cu${CUDA_VERSION%%.*}<3.6" \
       "${CUTLASS_DSL_PACKAGE}" \
-      'apache-tvm-ffi==0.1.9' && \
+      'apache-tvm-ffi==0.1.10' && \
     export FLASHINFER_LOCAL_VERSION="$(sed -E 's@([[:digit:]]+)\.([[:digit:]]+).*$@cu\1\2@')" \
       FLASHINFER_AOT_USE_PY_LIMITED_API='0' \
       FLASHINFER_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" && \
@@ -299,7 +299,7 @@ RUN apt-get -qq update && \
     apt-get clean && \
     python3 -m pip install --no-cache-dir meson meson-python ninja pybind11 tomlkit patchelf
 
-ARG NIXL_TAG='v1.2.0'
+ARG NIXL_TAG='v1.3.1'
 ARG NIXL_UCX_HOME='/opt/hpcx/ucx/mt'
 
 RUN --mount=type=secret,id=s3_access_key_id,env=AWS_ACCESS_KEY_ID \
@@ -327,15 +327,13 @@ RUN apt-get -qq update && \
     apt-get purge -y python3-jwt && \
     apt-get clean
 
-# vLLM 0.25 still pins nvidia-cutlass-dsl==4.5.2 (which renamed cutlass.base_dsl.Arch
-# -> arch) but only floors quack-kernels (>=0.3.3). A drifted quack still imports
-# the old `Arch` and crashes DeepSeek-V4's cute-DSL indexer at load. cutlass-dsl is
-# unchanged from 0.22.0, so keep quack pinned to the same known-good 0.4.1 release.
-# Revisit on the next vLLM bump.
+# vLLM 0.26 pins nvidia-cutlass-dsl==4.6.0 but only floors quack-kernels (>=0.4.0).
+# Keep Quack pinned to the release that declares the same exact CUTLASS DSL version
+# so the DeepSeek-V4 cute-DSL indexer cannot drift to an incompatible API.
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt && \
     echo 'click != 8.3.0' >> /tmp/constraints.txt && \
-    echo 'quack-kernels==0.4.1' >> /tmp/constraints.txt
+    echo 'quack-kernels==0.6.1' >> /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir "$(printf '%s[tensorizer,audio]' /tmp/wheels/*.whl)" -c /tmp/constraints.txt
@@ -371,7 +369,7 @@ ARG TARGETPLATFORM
 # * Kimi K2.5 tool-call scramble fixed in transformers 5.5.4 (huggingface/transformers#45359)
 # * Kimi K2.5 registry-subprocess SIGSEGV on GB200 with nixl-cu12 1.0.1 (vllm-project/vllm#40642) - verified
 #   no crash on this image with vllm 0.22
-# * llguidance pin mirrors vLLM 0.25's own requirement (>=1.7.0,<1.8.0); kept explicit so
+# * llguidance pin mirrors vLLM 0.26's own requirement (>=1.7.0,<1.8.0); kept explicit so
 #   JSON Schema "format": "uri" support (llguidance v1.6.0+) can't regress on future bumps
 
 # ray[cgraph]>=2.48.0 will unconditionally install cupy-cuda12x. Uninstall it and install cupy-cuda13x if CUDA major version is 13.
@@ -395,21 +393,24 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 
 # Swap the PyPI nixl for our MT-UCX build. Runs last because earlier installs (e.g. LMCache's
 # `nixl>=1.1.0`) pull the bundled-UCX wheel; purge those, install our wheel + the `nixl` meta
-# (the pure-python dispatcher) --no-deps so no bundled-UCX wheel comes back.
+# (the pure-python CUDA dispatcher) --no-deps so no bundled-UCX wheel comes back. NIXL 1.3's
+# meta also ships a `nixl_ep` dispatcher, but our UCX/POSIX-only build intentionally omits its
+# optional EP kernels. Remove that unusable dispatcher so vLLM does not discover and import it.
 RUN --mount=type=bind,from=nixl-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip uninstall -y nixl nixl-cu12 nixl-cu13 2>/dev/null; \
     rm -rf /usr/local/lib/python3.12/dist-packages/nixl* /usr/local/lib/python3.12/dist-packages/.nixl* && \
     python3 -m pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && \
-    python3 -m pip install --no-cache-dir --no-deps nixl==1.2.0 && \
+    python3 -m pip install --no-cache-dir --no-deps nixl==1.3.1 && \
     # Drop the meta's nixl-cuNN deps so downstream installs (e.g. modelexpress's `nixl[cu12]`) can't
     # pull a prebuilt bundled-UCX wheel back in; our build is the only backend.
     sed -i '/^Requires-Dist: nixl-cu1[23]/d' /usr/local/lib/python3.12/dist-packages/nixl-*.dist-info/METADATA && \
+    rm -rf /usr/local/lib/python3.12/dist-packages/nixl_ep && \
     # Assert the UCX plugin links HPC-X's MT UCX (LD_LIBRARY_PATH below selects it at runtime).
     P="$(find /usr/local/lib/python3.12/dist-packages -name 'libplugin_UCX.so' | head -1)" && \
     LD_LIBRARY_PATH="/opt/hpcx/ucx/mt/lib:${LD_LIBRARY_PATH}" ldd "$P" | grep -q "/opt/hpcx/ucx/mt/lib/libucp.so.0" || \
       { echo "NIXL UCX plugin not linked to HPC-X MT UCX:"; LD_LIBRARY_PATH="/opt/hpcx/ucx/mt/lib:${LD_LIBRARY_PATH}" ldd "$P"; exit 1; } && \
     LD_LIBRARY_PATH="/opt/hpcx/ucx/mt/lib:${LD_LIBRARY_PATH}" python3 -c \
-      "from importlib import util; from importlib.metadata import version; import nixl; assert version('nixl') == version('nixl-cu${CUDA_VERSION%%.*}'); assert util.find_spec('nixl_ep') is None; print('matching nixl dispatcher/backend import OK; incompatible nixl_ep absent')"
+      "from importlib import util; from importlib.metadata import version; import nixl; assert version('nixl') == version('nixl-cu${CUDA_VERSION%%.*}'); assert util.find_spec('nixl_ep') is None; assert util.find_spec('nixl_ep_cu${CUDA_VERSION%%.*}') is None; print('matching NIXL dispatcher/backend import OK; optional NIXL EP dispatcher/backend absent')"
 
 # Prepend MT UCX so its libucp wins over the base image's non-MT /opt/hpcx/ucx/lib.
 ENV LD_LIBRARY_PATH=/opt/hpcx/ucx/mt/lib:${LD_LIBRARY_PATH}


### PR DESCRIPTION
## Summary

- bump both vLLM tensorizer variants from vLLM 0.25.1 to [v0.26.0](https://github.com/vllm-project/vllm/releases/tag/v0.26.0)
- align explicit build/runtime pins with vLLM 0.26.0: CUTLASS DSL 4.6.0, Apache TVM FFI 0.1.10, and NIXL 1.3.1
- upgrade Quack kernels to 0.6.1, whose metadata pins the same CUTLASS DSL 4.6.0 API
- retain FlashInfer 0.6.14, LMCache 0.4.7, Torch 2.11.0, Transformers 5.9.0, DeepEP, and NVSHMEM because they remain compatible; no dependency is downgraded
- remove NIXL 1.3.1's unusable optional `nixl_ep` dispatcher when the corresponding EP kernels are intentionally absent, preventing vLLM 0.26 from discovering it and logging an import traceback

## Validation

- parsed the build matrix with `yq`
- verified the vLLM and dependency release tags/commits
- resolved the synchronized Python dependency set for Python 3.12 on Linux amd64 and arm64
- checked the custom vLLM Rust/CMake and NIXL HPC-X/UCX build assumptions against their new sources
- `git diff --check`
- [full vllm-tensorizer CI](https://github.com/coreweave/ml-containers/actions/runs/30302948360): both CUDA variants built and pushed successfully on amd64 and arm64, and both multi-architecture manifests merged
- live functional validation on an ARM64 NVIDIA GB300 in `cw4637-dev-eu-n-04a` using the CUDA 13.2 manifest digest `sha256:459e744ec73455d7ac89020f7a52f81ef19443e7aea77dbf9403633456deada6`:
  - imported vLLM, Torch/CUDA, NIXL, CUTLASS DSL, TVM FFI, Quack, FlashInfer, LMCache, and Tensorizer at their expected versions
  - ran eager and `torch.compile` BF16 GPU matrix multiplication on compute capability 10.3
  - started TP1 and TP2 vLLM servers with default compilation, FlashInfer `sm103`, CUDA graph capture, and a public Qwen2.5 model
  - exercised health, model listing, non-streaming chat, streaming chat including usage and `[DONE]`, and request metrics with no error or abort completions
  - confirmed TP2 NCCL initialization on both GPUs, direct P2P/CUMEM channels, and FlashInfer MNNVL all-reduce
  - confirmed the custom NIXL backend still links HPC-X MT UCX while `nixl_ep` is no longer discoverable; no NIXL/Python/vLLM error traceback remained

This is a functional release-candidate validation, not a throughput or latency benchmark.
