### PR TITLE
chore(modelexpress): Upgrade server to 0.5.0

### DIFF
--- a/.github/configurations/modelexpress-server.yml
+++ b/.github/configurations/modelexpress-server.yml
@@ -1,4 +1,4 @@
 modelexpress-commit:
-  - 'e72b140dfc71ee8769898ba750abd43b3c39e8b8'
+  - '4a337b653ed9f189ab9f43706796dd3d7139e313'
 modelexpress-port:
   - '8001'


### PR DESCRIPTION
Pin the server build to ModelExpress 4a337b653ed9f189ab9f43706796dd3d7139e313 so it matches the client revision embedded in the vLLM runtime and validated in the latest dev end-to-end test.