### PR TITLE
feat(vllm-tensorizer): Bump DeepGEMM to a6b593d2 for SM12x attention kernels

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -129,7 +129,7 @@ FROM vllm/vllm-openai:kimi-k3@sha256:e90e2603b2781936651ba019804137714367c69e10a
 
 FROM alpine/git:2.36.3 AS deepgemm-downloader
 WORKDIR /git
-ARG DEEPGEMM_COMMIT='f5a76426fa084087169693fd0cd815223576d6e9'
+ARG DEEPGEMM_COMMIT='a6b593d2826719dcf4892609af7b84ee23aaf32a'
 RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
       https://github.com/vllm-project/DeepGEMM && \
     cd DeepGEMM && \


### PR DESCRIPTION
Align `DEEPGEMM_COMMIT` with upstream vLLM main's pin (`cmake/external_projects/deepgemm.cmake`). The previous pin `f5a76426` ships paged-MQA logits kernels for SM90/SM100 only; `a6b593d2` (89 commits ahead, on the DeepGEMM nv_dev line — also reachable in vllm-project/DeepGEMM via nv_dev+situ) adds the arch-generalized smxx dispatch layer and the SM120 variants (`sm120_fp8_paged_mqa_logits`, `sm120_fp4_paged_mqa_logits`).

Without them, DeepSeek-V4's sparse-attention Lightning indexer asserts 'Unsupported architecture' (csrc/apis/attention.hpp:219) on RTX PRO 6000 (B40 / SM120), blocking DeepSeek-V4-family NVFP4 checkpoints on that hardware.

`a6b593d2` is upstream vLLM main's exact pin, so API compatibility with recent vLLM is by construction.