### PR TITLE
build(vllm-tensorizer): Bump `transformers` to 5.14.1 for GLM-5.2

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -389,7 +389,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     python3 -m pip install --no-cache-dir \
       accelerate hf_transfer 'modelscope!=1.15.0' "bitsandbytes>=${BITSANDBYTES_VER:?}" 'timm>=1.0.17' \
       'runai-model-streamer[s3,gcs]>=0.15.3' "ray[cgraph]>=2.48.0" \
-      'transformers==5.9.0' \
+      'transformers==5.14.1' \
       'llguidance>=1.7.0,<1.8.0' \
       -c /tmp/constraints.txt && \
     rm /tmp/constraints.txt && \


### PR DESCRIPTION
## Why

`nvidia/GLM-5.2-NVFP4` cannot be served on any image built from this base. GLM-5.2 (`GlmMoeDsaForCausalLM`) ships a `config.json` written by transformers 5.11.0 carrying `layer_types: ["deepseek_sparse_attention"] x 78`. Transformers below 5.11.0 rejects that value against `ALLOWED_LAYER_TYPES` during **config construction, before any weight is read**, so the worker CrashLoopBackOffs:

```
huggingface_hub.errors.StrictDataclassClassValidationError: Class validation error for validator 'validate_layer_type':
    ValueError: The `layer_types` entries must be in ('full_attention', 'sliding_attention', ... 'moe')
    but got ['deepseek_sparse_attention', ...]
```

`--hf-overrides` cannot work around this, because overrides are applied after the config object is built.

This is not GLM-specific in the long run: any DeepSeek-sparse-attention-family checkpoint published against 5.11.0+ will hit the same wall.

## Verification

Loaded the published `nvidia/GLM-5.2-NVFP4` `config.json` under each release:

| transformers | result |
|---|---|
| 5.9.0 (current pin) | `StrictDataclassClassValidationError` |
| 5.10.4 | `StrictDataclassClassValidationError` |
| 5.11.0 → 5.14.1 | OK → `GlmMoeDsaConfig`, 78 layers |

Do not screen candidate versions by grepping `ALLOWED_LAYER_TYPES`. In 5.13.0 that tuple shrinks from 15 entries to 10 and loses `deepseek_sparse_attention`, yet loading still succeeds because the config declares its own permitted types. I nearly drew the wrong conclusion from the constant alone.

## Why the tip and not the 5.11.0 floor

5.14.1 requires no transitive upgrades in this image. Checked inside `cw-infr-oci/dynamo-vllm:v2.29.1`, which builds on this base:

| requirement of 5.14.1 | already installed |
|---|---|
| `huggingface-hub<2.0,>=1.5.0` | 1.26.0 |
| `tokenizers<=0.23.0,>=0.22.0` | 0.22.2 |
| `safetensors>=0.8.0` | 0.8.0 |
| `regex>=2025.10.22` | 2026.7.19 |
| `tqdm>=4.60` | 4.70.0 |
| `numpy>=1.17` | 2.2.6 |

Relative to 5.9.0 the only requirement that moved at all is `safetensors`, from `>=0.4.3` to `>=0.8.0`, and the image is already exactly at 0.8.0.

## Nothing competes for this pin

- Generated constraints file bounds only the torch family plus `click` and `quack-kernels`.
- Downstream consumers declare floors with no upper bound: vllm `0.26.1.dev0` wants `transformers>=5.5.3`, ai-dynamo 1.4.0 wants `>=4.56.0`, compressed-tensors 0.17.0 wants `>=4.45.0`.
- `modelopt` is not installed in the serving image, so its `>=4.56,<5.10` pin does not apply. That pin is what forced a `--no-deps` override in our quantize image, and I expected it to block this bump; it does not.

The two prior reasons for this pin still hold: Gemma 4 MTP needs `>=5.9.0`, and the Kimi K2.5 tool-call fix landed in 5.5.4.

## What is NOT verified

**Only config construction.** I have not run a forward pass on this bump. The gate before promotion is a serve smoke test on the other models named in the comment block above the pin — Gemma 4 MTP, Kimi K2.5/K3, DeepSeek-V4 — since vLLM reaches into transformers internals in ways its declared floor does not capture.

If a full smoke test turns up trouble, 5.12.1 is the conservative fallback: it clears the GLM-5.2 floor, is the version our GLM-5.2 quantization tooling already runs, and is one patch above the 5.12.0 that zai-org used to serialize GLM-5.2 itself.

## Downstream chain

This is step 1 of 4. It needs to reach `coreweave/infr` (`images/vllm/Dockerfile:28` pins the base by `<ml-containers-sha>-<vllm-sha>`), which rebuilds `dynamo-vllm`, which then needs a new `<vllm-ver>+crwv.<n>` entry in `cks-inference-deploy` `config/values/runtime-engines.yaml`.

cc @alexeldeib