### PR TITLE
feat: Use release version of vllm 0.27

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,6 +1,6 @@
 include:
   # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.27.0rc2 versioning=pep440
-  - vllm-commit: '4dbf890219428c4682691cacbf97365f18c27c37'
+  - vllm-commit: '4bdc8a788d2e2ce9165d552b3d4d8b72604626bf'
     flashinfer-commit: 'v0.6.16.post3'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:8c5de3e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.13.0-vision0.28.0-audio2.11.0-abi1'


### PR DESCRIPTION
Minor insignificant differences from the rc2:
[[Model] Add K-EXAONE-2.0-750B-A37B (](https://github.com/vllm-project/vllm/commit/525832b395b5061a6d419e036bd9e410bf715476)https://github.com/vllm-project/vllm/pull/50524[)](https://github.com/vllm-project/vllm/commit/525832b395b5061a6d419e036bd9e410bf715476)

[[Kimi][MM] disable kimi_vit's dynamic torch.compile for TPU (](https://github.com/vllm-project/vllm/commit/e50f7d36960980c0c89651ffd0ce281a9fb8a466)https://github.com/vllm-project/vllm/pull/51196[)](https://github.com/vllm-project/vllm/commit/e50f7d36960980c0c89651ffd0ce281a9fb8a466)

[[Docs] Fix two docs build warnings (](https://github.com/vllm-project/vllm/commit/4bdc8a788d2e2ce9165d552b3d4d8b72604626bf)https://github.com/vllm-project/vllm/pull/51014[)](https://github.com/vllm-project/vllm/commit/4bdc8a788d2e2ce9165d552b3d4d8b72604626bf)