### PR TITLE
feat: Update DeepGEMM pin to follow upstream vLLM

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -123,7 +123,7 @@ WORKDIR /git
 # Match _DEEPGEMM_UPSTREAM_TAG in vLLM's cmake/external_projects/deepgemm.cmake
 # at VLLM_COMMIT (vllm-project/DeepGEMM); a stale wheel drifts from the JIT
 # interface vLLM was built against and breaks FP8 MoE GEMMs at serve time.
-ARG DEEPGEMM_COMMIT='e21c821f39a2056d68067a466c64ddc942200106'
+ARG DEEPGEMM_COMMIT='8b1392b978f5a03c828dd1711090d7fb50958b8a'
 RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
       https://github.com/vllm-project/DeepGEMM && \
     cd DeepGEMM && \


### PR DESCRIPTION
Upsteram vLLM updated the DeepGEMM commit to follow nv_dev branch at https://github.com/vllm-project/vllm/pull/52035