### PR TITLE
ci: Scope vLLM build caches by ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
         required: false
         description: "Optional sub-key to append to the image name for build layer caching"
         type: string
+      cache-scope:
+        required: false
+        description: "Optional scope for isolated cache writes with shared-cache fallback"
+        type: string
       platforms:
         required: false
         description: "Platforms for which to build (default: linux/amd64,linux/arm64)"
@@ -125,10 +129,26 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Compute cache key
         id: cache
+        env:
+          CACHE_SCOPE: ${{ inputs.cache-scope }}
         run: |
           KEY="${{ matrix.arch }}-${{ inputs.image-name }}"
           [ -z "${{ inputs.cache-key }}" ] || KEY="${KEY}-${{ inputs.cache-key }}"
-          echo "ref=${{ needs.prepare.outputs.registry }}/buildcache:${KEY}" >> "$GITHUB_OUTPUT"
+          SHARED_REF="${{ needs.prepare.outputs.registry }}/buildcache:${KEY}"
+          if [ -n "$CACHE_SCOPE" ]; then
+            SCOPE_HASH=$(printf '%s' "$CACHE_SCOPE" | sha256sum | cut -c1-12)
+            WRITE_REF="${SHARED_REF}-ref-${SCOPE_HASH}"
+            {
+              echo 'sources<<EOF'
+              echo "type=registry,ref=${WRITE_REF}"
+              echo "type=registry,ref=${SHARED_REF}"
+              echo 'EOF'
+              echo "destination=type=registry,ref=${WRITE_REF},mode=max"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "sources=type=registry,ref=${SHARED_REF}" >> "$GITHUB_OUTPUT"
+            echo "destination=type=registry,ref=${SHARED_REF},mode=max" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build and push by digest
         id: docker-build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
@@ -146,8 +166,8 @@ jobs:
           secrets: |
             ${{ inputs.object-storage-secrets && format('s3_access_key_id={0}', secrets.SCCACHE_S3_ACCESS_KEY_ID) || '' }}
             ${{ inputs.object-storage-secrets && format('s3_secret_access_key={0}', secrets.SCCACHE_S3_SECRET_ACCESS_KEY) || '' }}
-          cache-from: type=registry,ref=${{ steps.cache.outputs.ref }}
-          cache-to: type=registry,ref=${{ steps.cache.outputs.ref }},mode=max
+          cache-from: ${{ steps.cache.outputs.sources }}
+          cache-to: ${{ steps.cache.outputs.destination }}
       - name: Export digest
         id: export
         run: echo "digest-${{ matrix.arch }}=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ on:
         required: false
         description: "Optional scope for isolated cache writes with shared-cache fallback"
         type: string
+      cache-fallback-scope:
+        required: false
+        description: "Optional canonical scope to read before the legacy shared cache"
+        type: string
       platforms:
         required: false
         description: "Platforms for which to build (default: linux/amd64,linux/arm64)"
@@ -131,23 +135,29 @@ jobs:
         id: cache
         env:
           CACHE_SCOPE: ${{ inputs.cache-scope }}
+          CACHE_FALLBACK_SCOPE: ${{ inputs.cache-fallback-scope }}
         run: |
           KEY="${{ matrix.arch }}-${{ inputs.image-name }}"
           [ -z "${{ inputs.cache-key }}" ] || KEY="${KEY}-${{ inputs.cache-key }}"
-          SHARED_REF="${{ needs.prepare.outputs.registry }}/buildcache:${KEY}"
+          LEGACY_REF="${{ needs.prepare.outputs.registry }}/buildcache:${KEY}"
           if [ -n "$CACHE_SCOPE" ]; then
             SCOPE_HASH=$(printf '%s' "$CACHE_SCOPE" | sha256sum | cut -c1-12)
-            WRITE_REF="${SHARED_REF}-ref-${SCOPE_HASH}"
+            WRITE_REF="${LEGACY_REF}-ref-${SCOPE_HASH}"
             {
               echo 'sources<<EOF'
               echo "type=registry,ref=${WRITE_REF}"
-              echo "type=registry,ref=${SHARED_REF}"
+              if [ -n "$CACHE_FALLBACK_SCOPE" ]; then
+                FALLBACK_HASH=$(printf '%s' "$CACHE_FALLBACK_SCOPE" | sha256sum | cut -c1-12)
+                FALLBACK_REF="${LEGACY_REF}-ref-${FALLBACK_HASH}"
+                [ "$FALLBACK_REF" = "$WRITE_REF" ] || echo "type=registry,ref=${FALLBACK_REF}"
+              fi
+              echo "type=registry,ref=${LEGACY_REF}"
               echo 'EOF'
               echo "destination=type=registry,ref=${WRITE_REF},mode=max"
             } >> "$GITHUB_OUTPUT"
           else
-            echo "sources=type=registry,ref=${SHARED_REF}" >> "$GITHUB_OUTPUT"
-            echo "destination=type=registry,ref=${SHARED_REF},mode=max" >> "$GITHUB_OUTPUT"
+            echo "sources=type=registry,ref=${LEGACY_REF}" >> "$GITHUB_OUTPUT"
+            echo "destination=type=registry,ref=${LEGACY_REF},mode=max" >> "$GITHUB_OUTPUT"
           fi
       - name: Build and push by digest
         id: docker-build

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -5,6 +5,9 @@ on:
       - ".github/configurations/vllm-tensorizer.yml"
       - ".github/workflows/vllm-tensorizer.yml"
 
+concurrency:
+  group: vllm-tensorizer-${{ github.ref }}
+  queue: max
 
 jobs:
   get-config:
@@ -35,6 +38,7 @@ jobs:
       folder: vllm-tensorizer
       tag-suffix: ${{ matrix.tag-suffix }}
       cache-key: ${{ matrix.cache-key }}
+      cache-scope: ${{ github.ref_name != 'main' && github.ref_name || '' }}
       build-contexts: |
         common=common
       object-storage-secrets: true

--- a/.github/workflows/vllm-tensorizer.yml
+++ b/.github/workflows/vllm-tensorizer.yml
@@ -38,7 +38,8 @@ jobs:
       folder: vllm-tensorizer
       tag-suffix: ${{ matrix.tag-suffix }}
       cache-key: ${{ matrix.cache-key }}
-      cache-scope: ${{ github.ref_name != 'main' && github.ref_name || '' }}
+      cache-scope: ${{ github.ref_name }}
+      cache-fallback-scope: main
       build-contexts: |
         common=common
       object-storage-secrets: true


### PR DESCRIPTION
Let branch builds read the canonical shared cache while writing only to a ref-scoped cache. Queue runs per ref so every pushed SHA builds serially without cross-branch cache races or duplicate ARM contention. This avoids auto-cancellation which I recall Eta preferred, while permitting concurrency groups to prevent same-branch cache collisions.