### PR TITLE
fix(vllm): Correct multicast mailbox publication

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -86,6 +86,9 @@ RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
     git checkout "${VLLM_COMMIT}" && \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=tree:0
+COPY vllm-mnnvl-lamport-multimem-store.patch /git/patch
+RUN git -C vllm apply -v --stat --apply /git/patch && \
+    rm /git/patch
 
 FROM alpine/git:2.36.3 AS flashinfer-downloader
 WORKDIR /git

--- a/vllm-tensorizer/vllm-mnnvl-lamport-multimem-store.patch
+++ b/vllm-tensorizer/vllm-mnnvl-lamport-multimem-store.patch
@@ -1,0 +1,81 @@
+diff --git a/csrc/custom_all_gather_reduce_scatter.cuh b/csrc/custom_all_gather_reduce_scatter.cuh
+index ac990d810..a1eba2dda 100644
+--- a/csrc/custom_all_gather_reduce_scatter.cuh
++++ b/csrc/custom_all_gather_reduce_scatter.cuh
+@@ -59,7 +59,7 @@ DINLINE LamportPack<P> load_lamport_pack(const P* ptr) {
+   static_assert(sizeof(P) == 16);
+   LamportPack<P> value;
+ #if !defined(USE_ROCM)
+-  asm volatile("ld.volatile.global.v4.u32 {%0, %1, %2, %3}, [%4];"
++  asm volatile("ld.acquire.sys.global.v4.u32 {%0, %1, %2, %3}, [%4];"
+                : "=r"(value.words[0]), "=r"(value.words[1]),
+                  "=r"(value.words[2]), "=r"(value.words[3])
+                : "l"(ptr)
+@@ -104,6 +104,31 @@ DINLINE P sanitize_lamport_payload(P packed) {
+   return value.packed;
+ }
+ 
++template <typename P>
++DINLINE void store_multimem_lamport_payload(P* ptr, P packed) {
++  static_assert(sizeof(P) == 16);
++  // multimem was introduced in PTX 8.1 (CUDA 12.1) for SM90 and newer.
++#if !defined(USE_ROCM) && CUDA_VERSION >= 12010 && defined(__CUDA_ARCH__) && \
++    (__CUDA_ARCH__ >= 900)
++  LamportPack<P> value{.packed = packed};
++  asm volatile("multimem.st.release.sys.global.v4.f32 [%0], {%1,%2,%3,%4};"
++               :
++               : "l"(ptr), "r"(value.words[0]), "r"(value.words[1]),
++                 "r"(value.words[2]), "r"(value.words[3])
++               : "memory");
++  // The multicast and rank-local pointers are virtual aliases of the same
++  // allocations. Order the multicast publication before local-alias polling.
++  asm volatile("fence.proxy.alias;" : : : "memory");
++#elif defined(USE_ROCM)
++  __builtin_trap();
++#else
++  // Multicast mappings do not exist before SM90. Fail closed if this kernel is
++  // ever dispatched for an unsupported target instead of issuing an undefined
++  // ordinary store to a multicast address.
++  asm volatile("trap;");
++#endif
++}
++
+ template <typename P>
+ DINLINE P wait_lamport_payload(const P* ptr) {
+   auto value = load_lamport_pack(ptr);
+@@ -199,7 +224,9 @@ __global__ void __launch_bounds__(kMnnvlLamportAgThreads, 1)
+   int stride = gridDim.x * blockDim.x;
+   uint32_t epoch = epochs[0];
+   int current_stage = epoch % 3;
+-  int dirty_stage = (epoch + 1) % 3;
++  // A peer may start the next epoch after we publish but before we finish.
++  // Clean the previous stage, which cannot be reused until two epochs later.
++  int dirty_stage = (epoch + 2) % 3;
+   int dirty_size = epochs[2 + dirty_stage];
+   auto local_buffer = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+   auto current_local = local_buffer + current_stage * stage_size;
+@@ -213,8 +240,11 @@ __global__ void __launch_bounds__(kMnnvlLamportAgThreads, 1)
+   P local_value;
+   if (tid < size_per_rank) {
+     local_value = packed_input[tid];
+-    current_multicast[rank * size_per_rank + tid] =
+-        sanitize_lamport_payload(local_value);
++    // A CUDA multicast mapping may only be accessed with multimem PTX;
++    // ordinary global loads and stores have undefined behavior.
++    store_multimem_lamport_payload(
++        current_multicast + rank * size_per_rank + tid,
++        sanitize_lamport_payload(local_value));
+   }
+ #if !defined(USE_ROCM) && CUDA_VERSION >= 12000 && defined(__CUDA_ARCH__) && \
+     (__CUDA_ARCH__ >= 900)
+@@ -267,7 +297,9 @@ __global__ void __launch_bounds__(kMnnvlLamportRsThreads, 1)
+   int stride = gridDim.x * blockDim.x;
+   uint32_t epoch = epochs[0];
+   int current_stage = epoch % 3;
+-  int dirty_stage = (epoch + 1) % 3;
++  // A peer may start the next epoch after we publish but before we finish.
++  // Clean the previous stage, which cannot be reused until two epochs later.
++  int dirty_stage = (epoch + 2) % 3;
+   int dirty_size = epochs[2 + dirty_stage];
+   auto local_buffer = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+   auto current_local = local_buffer + current_stage * stage_size;


### PR DESCRIPTION
This is identical to https://github.com/coreweave/ml-containers/pull/213 but changes the `dirty_stage` calculation in a way that should ideally correct the invariant required.
```diff
-  int dirty_stage = (epoch + 1) % 3;
+  // A peer may start the next epoch after we publish but before we finish.
+  // Clean the previous stage, which cannot be reused until two epochs later.
+  int dirty_stage = (epoch + 2) % 3;
```
I'll either merge this or 213, I think this is "more correct", but want to validate before I decide.

---

CUDA multicast addresses refer to one symmetric buffer on several GPUs and may only be written with `multimem.*`; an ordinary store is undefined and can become visible late or partially, leaving peers to assemble incorrect hidden-state chunks that attention turns into fluent but unrelated text ([PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-multimem-ld-reduce-multimem-st-multimem-red)).

The observed failure used one eight-way tensor-parallel group spread across two GB300 nodes with four GPUs each; customer-visible corruption has only been reproduced on multi-node serving so far.

```bash
# Run on both hosts with NODE_RANK=0 or 1; LEADER names rank 0.
export NCCL_CUMEM_ENABLE=1 NCCL_NVLS_ENABLE=0
python3 -m dynamo.vllm \
  --model /tmp/model \
  --served-model-name DeepSeek-V4-Pro-0813 \
  --distributed-executor-backend mp \
  --nnodes 2 --node-rank "$NODE_RANK" \
  --master-addr "$LEADER" --master-port 29500 \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --moe-backend deep_gemm_mega_moe \
  --attention-config.mla_prefill_backend TRTLLM_RAGGED \
  --attention-config.use_fp4_indexer_cache true \
  --compilation-config.mode 3 \
  --kv-cache-dtype fp8 \
  --speculative-config.method dspark \
  --speculative-config.num_speculative_tokens 7

curl "$BASE/v1/responses" -H 'Content-Type: application/json' -d \
  '{"model":"DeepSeek-V4-Pro-0813","input":"What color is the sky on a clear day? One word.","max_output_tokens":500,"stream":false}'
# Expected: Blue
# Observed: fluent unrelated text, e.g. Japanese baseball commentary and "Petridiculously..."
```

Publish each mailbox entry with a system-wide release multicast store, order the multicast and local virtual-address aliases with `fence.proxy.alias`, and poll the local copy with acquire loads ([CUDA virtual aliasing](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/virtual-memory-management.html#virtual-aliasing-support)).

Clean the previously used stage rather than the next stage: a peer may begin the next epoch after publication but before cleanup, while the previous stage cannot be reused until every rank has completed the intervening epoch.

DeepSeek-V4 with MegaMoE, expert parallelism, and eight-way tensor parallelism reaches this mailbox through sequence-parallel all-gather and reduce-scatter; current K3 and DeepSeek-V4 with expert parallelism disabled do not. Four-way and single-node tests did not reproduce corruption but can still select the same kernel when CUDA multicast is available, so the defined fix applies there too; the CUDA 12.1/SM90 guard supports Hopper and Blackwell and traps unsupported paths.