### PR TITLE
feat: Bump vllm to 0.28 release

### DIFF
--- a/.github/configurations/vllm-tensorizer.yml
+++ b/.github/configurations/vllm-tensorizer.yml
@@ -1,6 +1,6 @@
 include:
-  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.27.0rc2 versioning=pep440
-  - vllm-commit: '4bdc8a788d2e2ce9165d552b3d4d8b72604626bf'
+  # renovate-release: datasource=github-releases depName=vllm-project/vllm currentValue=v0.28.0 versioning=pep440
+  - vllm-commit: '2cf0a6915ce544dc493a0990f2ea38d81601128a'
     flashinfer-commit: 'v0.6.16.post3'
     lmcache-commit: 'v0.4.7'
     builder-base-image: 'ghcr.io/coreweave/ml-containers/torch:8c5de3e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.13.0-vision0.28.0-audio2.11.0-abi1'

--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -354,13 +354,13 @@ RUN apt-get -qq update && \
     apt-get purge -y python3-jwt && \
     apt-get clean
 
-# vLLM 0.27 pins nvidia-cutlass-dsl==4.6.0 but only floors quack-kernels (>=0.6.1).
+# vLLM 0.27 pins nvidia-cutlass-dsl==4.6.2 but only floors quack-kernels (>=0.6.4).
 # Keep Quack pinned to the release that declares the same exact CUTLASS DSL version
 # so the DeepSeek-V4 cute-DSL indexer cannot drift to an incompatible API.
 RUN --mount=type=bind,from=freezer,target=/tmp/frozen \
     /tmp/frozen/freeze.sh torch torchaudio torchvision xformers > /tmp/constraints.txt && \
     echo 'click != 8.3.0' >> /tmp/constraints.txt && \
-    echo 'quack-kernels==0.6.1' >> /tmp/constraints.txt
+    echo 'quack-kernels==0.6.4' >> /tmp/constraints.txt
 
 RUN --mount=type=bind,from=vllm-builder,source=/wheels,target=/tmp/wheels \
     python3 -m pip install --no-cache-dir "$(printf '%s[tensorizer,audio]' /tmp/wheels/*.whl)" -c /tmp/constraints.txt


### PR DESCRIPTION
vLLM 0.28.0 was released as https://github.com/vllm-project/vllm/commit/2cf0a6915ce544dc493a0990f2ea38d81601128a
Flashinfer commit remains unchanged