### PR TITLE
ci(sglang): Build 0.5.17 and 0.5.18 images

### DIFF
--- a/.github/configurations/sglang.yml
+++ b/.github/configurations/sglang.yml
@@ -6,3 +6,7 @@ base-image:
 tag:
   # renovate-release-tag: datasource=github-releases depName=sgl-project/sglang versioning=pep440
   - 'v0.5.18-cuda13.2.1-torch2.13.0'
+include:
+  - sglang-commit: '29481685462732237d80d86076d6563e1f658102'
+    base-image: 'ghcr.io/coreweave/ml-containers/torch-extras:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
+    tag: 'v0.5.17-cuda13.2.1-torch2.11.0'

--- a/.github/configurations/sglang.yml
+++ b/.github/configurations/sglang.yml
@@ -1,12 +1,9 @@
-sglang-commit:
-  # renovate-release: datasource=github-releases depName=sgl-project/sglang currentValue=v0.5.18 versioning=pep440
-  - '71de97b264b04dcd514cf904003028aefe9775c8'
-base-image:
-  - 'ghcr.io/coreweave/ml-containers/torch-extras:8c5de3e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.13.0-vision0.28.0-audio2.11.0-abi1'
-tag:
-  # renovate-release-tag: datasource=github-releases depName=sgl-project/sglang versioning=pep440
-  - 'v0.5.18-cuda13.2.1-torch2.13.0'
 include:
+  # renovate-release: datasource=github-releases depName=sgl-project/sglang currentValue=v0.5.18 versioning=pep440
+  - sglang-commit: '71de97b264b04dcd514cf904003028aefe9775c8'
+    base-image: 'ghcr.io/coreweave/ml-containers/torch-extras:8c5de3e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.13.0-vision0.28.0-audio2.11.0-abi1'
+    # renovate-release-tag: datasource=github-releases depName=sgl-project/sglang versioning=pep440
+    tag: 'v0.5.18-cuda13.2.1-torch2.13.0'
   - sglang-commit: '29481685462732237d80d86076d6563e1f658102'
     base-image: 'ghcr.io/coreweave/ml-containers/torch-extras:bc8c66e-nccl-cuda13.2.1-ubuntu24.04-nccl2.30.4-1-torch2.11.0-vision0.26.0-audio2.11.0-abi1'
     tag: 'v0.5.17-cuda13.2.1-torch2.11.0'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,7 @@
       ],
       matchStrings: [
         "# renovate-release: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) currentValue=(?<currentValue>\\S+) versioning=(?<versioning>\\S+)\\n[ \\t]*- (?:[a-z-]+: )?'?(?<currentDigest>[0-9a-f]{40})'?",
-        "# renovate-release-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n[ \\t]*- '(?<currentValue>v?[0-9][^'-]*)(?:-[^']*)?'",
+        "# renovate-release-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n[ \\t]*(?:- )?(?:[a-z-]+: )?'(?<currentValue>v?[0-9][^'-]*)(?:-[^']*)?'",
       ],
     },
   ],

--- a/.github/workflows/sglang.yml
+++ b/.github/workflows/sglang.yml
@@ -25,6 +25,7 @@ jobs:
       object-storage-secrets: true
       build-contexts: common=common
       tag-suffix: ${{ matrix.tag }}
+      cache-key: ${{ matrix.tag }}
       build-args: |
         BASE_IMAGE=${{ matrix.base-image }}
         SGLANG_COMMIT=${{ matrix.sglang-commit }}

--- a/sglang/build.bash
+++ b/sglang/build.bash
@@ -49,8 +49,9 @@ cd sglang
 git checkout "${SGLANG_COMMIT}"
 
 # Relax exact torch-family version pins to be compatible with the base image
+TORCH_VERSION="$(python3 -c 'import torch; print(torch.__version__.partition("+")[0])')"
 sed -Ei \
-  -e 's@"torch==[0-9]+\.[0-9]+\.[0-9]+"@"torch>=2.13.0"@' \
+  -e "s@\"torch==[0-9]+\.[0-9]+\.[0-9]+\"@\"torch>=${TORCH_VERSION}\"@" \
   -e 's@"torchaudio==[0-9]+\.[0-9]+\.[0-9]+"@"torchaudio>=2.11.0"@' \
   -e 's@"torchao==[0-9]+\.[0-9]+\.[0-9]+"@"torchao>=0.17.0"@' \
   -e 's@"torchcodec==[0-9]+\.[0-9]+\.[0-9]+@"torchcodec@' \

--- a/sglang/install.bash
+++ b/sglang/install.bash
@@ -21,7 +21,12 @@ ldconfig
 
 # Compile and exercise the lazy HiCache hash extension during the image build.
 # This catches missing C++ headers or libcrypto linkage before request traffic
-# reaches the Mamba radix-cache event path.
+# reaches the Mamba radix-cache event path. Keep the build-host-specific module
+# out of the final image so runtime compilation targets the serving host CPU.
+TORCH_EXTENSIONS_DIR="$(mktemp -d)"
+export TORCH_EXTENSIONS_DIR
+trap 'rm -rf "${TORCH_EXTENSIONS_DIR}"' EXIT
+
 python3 - <<'PY'
 from sglang.srt.mem_cache.cpp_utils.native_hash import get_native_hash
 

--- a/sglang/install.bash
+++ b/sglang/install.bash
@@ -21,12 +21,7 @@ ldconfig
 
 # Compile and exercise the lazy HiCache hash extension during the image build.
 # This catches missing C++ headers or libcrypto linkage before request traffic
-# reaches the Mamba radix-cache event path. Keep the build-host-specific module
-# out of the final image so runtime compilation targets the serving host CPU.
-TORCH_EXTENSIONS_DIR="$(mktemp -d)"
-export TORCH_EXTENSIONS_DIR
-trap 'rm -rf "${TORCH_EXTENSIONS_DIR}"' EXIT
-
+# reaches the Mamba radix-cache event path.
 python3 - <<'PY'
 from sglang.srt.mem_cache.cpp_utils.native_hash import get_native_hash
 


### PR DESCRIPTION
## Summary

- build SGLang 0.5.17 alongside the default 0.5.18 image using explicit release matrix rows
- use the compatible Torch 2.11 base for 0.5.17 and Torch 2.13 base for 0.5.18
- isolate build caches by matrix tag
- derive the relaxed Torch lower bound from each selected base image
- preserve Renovate updates for the latest release commit and image tag