### PR TITLE
fix(vllm): Align SM120 sparse cache pages

### DIFF
--- a/vllm-tensorizer/Dockerfile
+++ b/vllm-tensorizer/Dockerfile
@@ -104,6 +104,10 @@ RUN git clone --filter=tree:0 --no-single-branch --no-checkout \
     git submodule update --init --recursive --jobs 8 \
       --depth 1 --filter=tree:0
 
+COPY flashinfer-patches/ /git/flashinfer-patches/
+RUN git -C flashinfer apply -v --stat --apply /git/flashinfer-patches/*.patch && \
+    rm -rf /git/flashinfer-patches
+
 FROM alpine/git:2.36.3 AS lmcache-downloader
 WORKDIR /git
 ARG LMCACHE_COMMIT

--- a/vllm-tensorizer/flashinfer-patches/0001-sm120-dsv41-prefill-pages.patch
+++ b/vllm-tensorizer/flashinfer-patches/0001-sm120-dsv41-prefill-pages.patch
@@ -1,0 +1,44 @@
+diff --git a/csrc/sparse_mla_sm120_prefill.cu b/csrc/sparse_mla_sm120_prefill.cu
+index 0c988ca..bc16d35 100644
+--- a/csrc/sparse_mla_sm120_prefill.cu
++++ b/csrc/sparse_mla_sm120_prefill.cu
+@@ -322,7 +322,7 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
+                                const int* topk_length_ptr, const int* topk_length_extra_ptr,
+                                cudaStream_t stream) {
+   if (topk == 128 && topk_length_ptr == nullptr && topk_length_extra_ptr == nullptr &&
+-      topk_extra % BI == 0 && (extra_page_block_size == 64 || extra_page_block_size == 2)) {
++      topk_extra % BI == 0 && (extra_page_block_size == 64 || extra_page_block_size == 128 || extra_page_block_size == 2)) {
+ #define DISPATCH_DUAL_MG_FULLTILE(NH, TK, PBSX, NHG)                                         \
+   launch_prefill_mg_dual_fulltile<ModelType::DSV4, NH, TK, 64, PBSX, NHG>(                   \
+       Q, KV, indices, KV_extra, idx_extra, attn_sink, output, out_lse, sm_scale, num_tokens, \
+@@ -353,6 +353,8 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
+ 
+     if (extra_page_block_size == 64) {
+       DISPATCH_FULLTILE_BY_NH_PBSX(64);
++    } else if (extra_page_block_size == 128) {
++      DISPATCH_FULLTILE_BY_NH_PBSX(128);
+     } else {
+       DISPATCH_FULLTILE_BY_NH_PBSX(2);
+     }
+@@ -394,6 +396,8 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
+   if (topk != 128) return false;
+   if (extra_page_block_size == 64) {
+     DISPATCH_BY_NH_PBSX(64);
++  } else if (extra_page_block_size == 128) {
++    DISPATCH_BY_NH_PBSX(128);
+   } else if (extra_page_block_size == 2) {
+     DISPATCH_BY_NH_PBSX(2);
+   }
+diff --git a/flashinfer/jit/mla.py b/flashinfer/jit/mla.py
+index 6c11d54..06eda19 100644
+--- a/flashinfer/jit/mla.py
++++ b/flashinfer/jit/mla.py
+@@ -43,7 +43,7 @@ def gen_sparse_mla_sm120_module() -> JitSpec:
+         supported_major_versions=[12]
+     )
+     return gen_jit_spec(
+-        "sparse_mla_sm120",
++        "sparse_mla_sm120_dsv41",
+         [
+             jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120.cu",
+             jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120_decode_dsv3_2.cu",

--- a/vllm-tensorizer/tests/sm120/README.md
+++ b/vllm-tensorizer/tests/sm120/README.md
@@ -1,0 +1,66 @@
+# DeepSeek V4.1 Flash on SM120
+
+This draft stack extends the development image in
+[PR 227](https://github.com/coreweave/ml-containers/pull/227).
+It is independent of the Dynamo frontend patch stack and does not change
+Grace Blackwell deployment configuration.
+
+## Source and build contract
+
+- Parent image branch: `ace/dsv41-flash`, commit
+  `a5124aedb9c720b888274de6832bd2bb3d7e2b49`.
+- vLLM source: `40e6042ec83eb8f2971f21043a5da40496bd188a`, plus the parent's
+  reconciled V4.1 integration from PR 56214 at
+  `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`.
+- FlashInfer source: `8bc3b578027791336c6ae87db5c9d76f82cef8bc`, version
+  `0.6.18.post1`.
+- The parent development image deliberately includes initial V4.1 runtime
+  integration in its compiled wheel. This stack uses that same build path so
+  vLLM cache allocation and FlashInfer kernels ship together. It does not add
+  these Python changes to the released runtime's separate patch queue.
+
+The first layer selects 64-entry sliding-window pages only on SM120 and
+instantiates FlashInfer's existing dual-cache prefill template for 128-entry
+extra pages. The JIT module name changes to `sparse_mla_sm120_dsv41` to prevent
+loading a stock precompiled module with incompatible dispatch. FlashInfer
+patches run before its Python, cubin, and JIT-cache wheels are built.
+Other CUDA capability families retain their existing sliding-window page size.
+
+## Earlier validation baseline
+
+Earlier isolated checks passed on an NVIDIA RTX PRO 6000 Blackwell Server
+Edition GPU with compute capability 12.0. They used a derived runtime based on
+`vllm/vllm-openai:deepseekv41-flash-0909@sha256:00d577a6a63281e15336029d5bcee4e9a2cf182214a4f20ba6111b1c8e79893d`,
+vLLM `0.1.dev20904+g179dd0fa9`, FlashInfer `0.6.18`, torch `2.13.0+cu130`,
+and CUDA runtime `13.0`. The rebased image instead follows the parent branch's
+CUDA `13.2.1` build. Earlier results do not validate that rebuilt image.
+
+The stock image rejected 32-entry sliding-window pages on SM120. After that
+page-size correction, stock prefill still rejected `extra_page_block_size=128`.
+Eight sparse-attention cases then passed with 8 heads, 64-entry sliding-window
+pages, 64/128-entry extra pages, 1/65 query tokens, and full/runtime lengths.
+The maximum absolute output error was at most `0.00341796875`; relative RMSE
+was below `0.024`. The reference dequantizes the actual packed FP8 operands,
+so these results include internal attention precision loss but not initial KV
+quantization error.
+
+## Reproduce kernel checks
+
+Run the probe in the built image on an SM120 GPU. It loads no model weights.
+The two commands exercise the ratio-1 compressed-cache page in decode and
+prefill. Both must print a JSON record with `status` equal to `passed`.
+
+```bash
+python3 vllm-tensorizer/tests/sm120/check_sm120_cache_geometry.py --num-tokens 1 --extra-block-size 128 --padded-pages
+python3 vllm-tensorizer/tests/sm120/check_sm120_cache_geometry.py --num-tokens 65 --extra-block-size 128 --padded-pages
+```
+
+Repeat with `--extra-block-size 64` and with `--full-lengths` to cover the eight
+cases. The probe checks finite outputs and log-sum-exp, `atol=0.01, rtol=0.05`
+for output, `atol=0.05, rtol=0.05` for log-sum-exp, and relative RMSE below 0.05.
+
+The rebased source patches pass application checks and Python syntax checks.
+A new image build and SM120 GPU run are pending. Record the final image digest,
+instance type, GPU count, package versions, commands, and results before
+marking this stack ready. Kernel checks alone do not prove full-model serving,
+DSpark, concurrency, or multimodal support.

--- a/vllm-tensorizer/tests/sm120/check_sm120_cache_geometry.py
+++ b/vllm-tensorizer/tests/sm120/check_sm120_cache_geometry.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Exercise the V4.1 sparse cache geometry against the FlashInfer reference."""
+
+import argparse
+import json
+
+import torch
+from flashinfer.mla._sparse_mla_sm120 import (
+    _sparse_mla_sm120_paged_attention as sparse_attention,
+)
+
+def _cast_scale_inv_to_ue8m0(scales_inv: torch.Tensor) -> torch.Tensor:
+    """Round inverse scale to the nearest power-of-2 (FlashMLA convention)."""
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil())
+
+
+def _fp32_to_ue8m0_bytes(scale_fp32: torch.Tensor) -> torch.Tensor:
+    """Extract the IEEE-754 exponent byte of an FP32 power-of-2 scale."""
+    bits = scale_fp32.to(torch.float32).view(torch.int32)
+    return ((bits >> 23) & 0xFF).to(torch.uint8)
+
+
+def quantize_kv_dsv4(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack bf16 KV into DSv4 FP8 FOOTER format."""
+    d_nope, d_rope, tile_size, num_tiles = 448, 64, 64, 7
+    data_stride = d_nope + d_rope * 2  # 576
+    scale_bytes = num_tiles + 1  # 8
+    bpt = data_stride + scale_bytes  # 584
+    nb, bs, hk, d = kv_bf16.shape
+    assert d == 512 and hk == 1
+    kv = kv_bf16.squeeze(2)
+
+    block_bytes = bs * bpt
+    result_flat = torch.zeros(nb, block_bytes, dtype=torch.uint8, device=kv.device)
+
+    for ti in range(num_tiles):
+        tile = kv[..., ti * tile_size : (ti + 1) * tile_size].float()
+        amax = tile.abs().amax(dim=-1).clamp(min=1e-4)
+        scale = _cast_scale_inv_to_ue8m0(amax / 448.0)
+        fp8 = (tile / scale.unsqueeze(-1)).clamp(-448, 448).to(torch.float8_e4m3fn)
+        ue8m0 = _fp32_to_ue8m0_bytes(scale)
+
+        for tok in range(bs):
+            data_off = tok * data_stride + ti * tile_size
+            result_flat[:, data_off : data_off + tile_size] = fp8[:, tok].view(
+                torch.uint8
+            )
+            scale_off = bs * data_stride + tok * scale_bytes + ti
+            result_flat[:, scale_off] = ue8m0[:, tok]
+
+    rope = kv[..., d_nope:].to(torch.bfloat16).contiguous().view(torch.uint8)
+    rope = rope.reshape(nb, bs, d_rope * 2)
+    for tok in range(bs):
+        rope_off = tok * data_stride + d_nope
+        result_flat[:, rope_off : rope_off + d_rope * 2] = rope[:, tok]
+
+    return result_flat.view(nb, bs, 1, bpt)
+
+
+def dequantize_kv_dsv4(packed: torch.Tensor) -> torch.Tensor:
+    """Unpack DSV4 FP8 FOOTER → bf16. Inverse of :func:`quantize_kv_dsv4`."""
+    d_nope, d_rope, tile_size, num_tiles = 448, 64, 64, 7
+    data_stride = d_nope + d_rope * 2
+    scale_bytes = num_tiles + 1
+    bpt = data_stride + scale_bytes
+    nb, bs, _, _ = packed.shape
+    result = torch.zeros(nb, bs, 512, dtype=torch.bfloat16, device=packed.device)
+    p = packed.view(nb, bs * bpt)
+
+    for tok in range(bs):
+        data_off = tok * data_stride
+        scale_off = bs * data_stride + tok * scale_bytes
+        for ti in range(num_tiles):
+            fp8_off = data_off + ti * tile_size
+            fp8 = p[:, fp8_off : fp8_off + tile_size].view(torch.float8_e4m3fn).float()
+            ue8m0 = p[:, scale_off + ti]
+            scale = torch.pow(2.0, ue8m0.float() - 127.0)
+            result[:, tok, ti * tile_size : (ti + 1) * tile_size] = (
+                fp8 * scale.unsqueeze(-1)
+            ).to(torch.bfloat16)
+        rope_off = data_off + d_nope
+        rope_bytes = p[:, rope_off : rope_off + d_rope * 2].contiguous()
+        result[:, tok, d_nope:] = rope_bytes.view(torch.bfloat16).reshape(nb, d_rope)
+
+    return result.view(nb, bs, 1, 512)
+
+
+def _ref_sparse_attn(
+    q: torch.Tensor,
+    kv_dequant: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    d_v: int,
+    attn_sink: torch.Tensor | None = None,
+    topk_length: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dense SDPA over sparse-gathered KV."""
+    num_tokens, num_heads, d_qk = q.shape
+    topk = indices.shape[-1]
+
+    kv_flat = kv_dequant.view(-1, d_qk).float()
+    q_f = q.float()
+
+    idx_fixed = indices.clamp(min=0)
+    invalid = indices < 0
+    if topk_length is not None:
+        ar = torch.arange(topk, device=q.device).unsqueeze(0)
+        invalid = invalid | (ar >= topk_length.unsqueeze(-1))
+
+    gathered = kv_flat.index_select(0, idx_fixed.view(-1)).view(num_tokens, topk, d_qk)
+    P = torch.einsum("thd,tkd->thk", q_f, gathered) * sm_scale
+    P[invalid.unsqueeze(1).expand_as(P)] = float("-inf")
+
+    lse_e = torch.logsumexp(P, dim=-1)
+    lse_safe = lse_e.clone()
+    lse_safe[lse_safe == float("-inf")] = float("+inf")
+    weights = torch.exp(P - lse_safe.unsqueeze(-1))
+    out_f = torch.einsum("thk,tkd->thd", weights, gathered[..., :d_v])
+
+    LN2 = float(torch.log(torch.tensor(2.0)).item())
+    lse_log2 = lse_e / LN2
+
+    if attn_sink is not None:
+        sink = attn_sink.float()
+        sink_log2 = sink / LN2
+        factor = torch.sigmoid(lse_e.float() - sink.unsqueeze(0))
+        out_f = out_f * factor.unsqueeze(-1)
+        lse_log2 = torch.where(
+            lse_log2 == float("-inf"),
+            sink_log2.unsqueeze(0).expand_as(lse_log2),
+            lse_log2 + torch.log2(1.0 + torch.exp2(sink_log2.unsqueeze(0) - lse_log2)),
+        )
+
+    return out_f.to(torch.bfloat16), lse_log2
+
+
+def _make_decode_scratch(
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    d_v: int,
+    device: torch.device,
+    *,
+    extra_topk: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_splits = (topk + 63) // 64 + (extra_topk + 63) // 64
+    return (
+        torch.empty(
+            (num_tokens, num_heads, num_splits, d_v),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        torch.empty(
+            (num_tokens, num_heads, num_splits),
+            dtype=torch.float32,
+            device=device,
+        ),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--swa-block-size", type=int, default=64)
+    parser.add_argument("--extra-block-size", type=int, default=128)
+    parser.add_argument("--num-tokens", type=int, default=65)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--padded-pages", action="store_true")
+    parser.add_argument("--full-lengths", action="store_true")
+    args = parser.parse_args()
+    torch.manual_seed(20260910)
+    device = torch.device("cuda")
+    assert torch.cuda.get_device_capability()[0] == 12
+    query_count, heads = args.num_tokens, args.num_heads
+    total_main, total_extra = 512, 2048
+    main = torch.randn(total_main // args.swa_block_size, args.swa_block_size, 1, 512, device=device, dtype=torch.bfloat16) * 0.5
+    extra = torch.randn(total_extra // args.extra_block_size, args.extra_block_size, 1, 512, device=device, dtype=torch.bfloat16) * 0.5
+    main_packed = quantize_kv_dsv4(main)
+    extra_packed = quantize_kv_dsv4(extra)
+    main_dequant = dequantize_kv_dsv4(main_packed)
+    extra_dequant = dequantize_kv_dsv4(extra_packed)
+    if args.padded_pages:
+        def pad_pages(packed):
+            page_bytes = packed.shape[1] * 584
+            page_stride = (page_bytes + 575) // 576 * 576
+            storage = torch.full((packed.shape[0], page_stride), 255, device=device, dtype=torch.uint8)
+            view = storage[:, :page_bytes].view(packed.shape)
+            view.copy_(packed)
+            return view
+        main_packed = pad_pages(main_packed)
+        extra_packed = pad_pages(extra_packed)
+    query = torch.randn(query_count, heads, 512, device=device, dtype=torch.bfloat16) * 0.5
+    main_indices = torch.randint(total_main, (query_count, 128), device=device, dtype=torch.int32)
+    extra_indices = torch.randint(total_extra, (query_count, 512), device=device, dtype=torch.int32)
+    main_lengths = 64 + torch.arange(query_count, device=device, dtype=torch.int32) % 65
+    extra_lengths = 256 + torch.arange(query_count, device=device, dtype=torch.int32) % 257
+    if args.full_lengths:
+        main_lengths.fill_(128)
+        extra_lengths.fill_(512)
+    main_indices[:, 3] = -1
+    extra_indices[:, 11] = -1
+    sinks = torch.randn(heads, device=device)
+    virtual_kv = torch.cat((main_dequant.reshape(-1, 512), extra_dequant.reshape(-1, 512))).reshape(-1, 1, 1, 512)
+    main_reference = main_indices.masked_fill(torch.arange(128, device=device)[None, :] >= main_lengths[:, None], -1)
+    extra_reference = extra_indices.masked_fill(torch.arange(512, device=device)[None, :] >= extra_lengths[:, None], -1)
+    shifted_extra = torch.where(extra_reference >= 0, extra_reference + total_main, -1)
+    virtual_indices = torch.cat((main_reference, shifted_extra), dim=1)
+    expected, expected_lse = _ref_sparse_attn(query, virtual_kv, virtual_indices, 512**-0.5, 512, sinks)
+    actual = torch.empty_like(expected)
+    actual_lse = torch.empty_like(expected_lse)
+    mid_out, mid_lse = _make_decode_scratch(query_count, heads, 128, 512, device, extra_topk=512)
+    sparse_attention(query, main_packed, main_indices, actual, actual_lse, 512**-0.5,
+                     attn_sink=sinks, topk_length=None if args.full_lengths else main_lengths,
+                     extra_kv_cache=extra_packed, extra_indices=extra_indices,
+                     extra_topk_length=None if args.full_lengths else extra_lengths, mid_out=mid_out, mid_lse=mid_lse)
+    torch.cuda.synchronize()
+    assert torch.isfinite(actual).all(), "attention output is not finite"
+    assert torch.isfinite(actual_lse).all(), "attention LSE is not finite"
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=5e-2)
+    torch.testing.assert_close(actual_lse, expected_lse, atol=5e-2, rtol=5e-2)
+    error = actual.float() - expected.float()
+    relative_rmse = (error.square().mean() / expected.float().square().mean()).sqrt().item()
+    assert relative_rmse < 0.05, relative_rmse
+    print(json.dumps({"status": "passed", **vars(args), "max_abs_error": error.abs().max().item(), "relative_rmse": relative_rmse}))
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm-tensorizer/vllm-patches/0002-sm120-swa-cache-pages.patch
+++ b/vllm-tensorizer/vllm-patches/0002-sm120-swa-cache-pages.patch
@@ -1,0 +1,21 @@
+diff --git a/vllm/models/deepseek_v4_1/attention.py b/vllm/models/deepseek_v4_1/attention.py
+index 77e98a3..8227a5c 100644
+--- a/vllm/models/deepseek_v4_1/attention.py
++++ b/vllm/models/deepseek_v4_1/attention.py
+@@ -51,6 +51,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
+ from vllm.model_executor.models.utils import extract_layer_index
+ from vllm.models.deepseek_v4_1.common.rope import build_deepseek_v4_rope
+ from vllm.models.deepseek_v4_1.compressor import DeepseekCompressor
++from vllm.platforms import current_platform
+ from vllm.triton_utils import tl, triton
+ from vllm.utils.multi_stream_utils import (
+     execute_in_parallel,
+@@ -453,7 +454,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+             prefix=f"{prefix}.swa_cache",
+             cache_config=cache_config,
+             backend_cls=self.swa_backend_cls,
+-            block_size=32,
++            block_size=64 if current_platform.is_device_capability_family(120) else 32,
+         )
+ 
+         # The attention layer itself was already registered with the

--- a/vllm-tensorizer/vllm-patches/README.md
+++ b/vllm-tensorizer/vllm-patches/README.md
@@ -28,3 +28,10 @@ V4.1 requires a rebuilt runtime because the prior released base lacks its
 native kernels and Rust frontend. Once this image exists, its remaining
 Python integration can be iterated in the downstream infr patch layer.
 This branch is a development integration, not evidence of production rollout.
+
+## SM120 development stack
+
+The numbered SM120 patches extend the initial V4.1 development integration.
+Keep their cache geometry aligned with `../flashinfer-patches`.
+See [the SM120 validation guide](../tests/sm120/README.md) for source pins,
+reproduction commands, earlier test evidence, and remaining validation.


### PR DESCRIPTION
DeepSeek V4.1 Flash allocates 32-entry sliding-window cache pages that SM120 sparse attention rejects. Select 64 entries on SM120 and add FlashInfer prefill dispatch for the model's 128-entry compressed-cache pages. Use a separate JIT module name so the patched path cannot load the stock precompiled module.

This starts a separate SM120 draft stack on top of #227 (`ace/dsv41-flash`). The parent's initial V4.1 integration packages runtime and compiled source together; this stack uses that same build path. It is independent of the Dynamo frontend stack and does not alter Grace Blackwell deployment configuration.

The changes are rebased onto vLLM `40e6042e` plus the parent's integration patch and FlashInfer `8bc3b578` (`0.6.18.post1`). Included documentation records the earlier public base image, package versions, RTX PRO 6000 Blackwell hardware, numerical checks, and their limits. The GPU probe preserves its upstream reference license.

Validation: patch application and Python syntax checks pass. The earlier eight GPU cases passed on the older documented baseline; a rebuilt-image test remains pending. The next layers address indexer page allocation and text-only attention metadata.

@alexeldeib
