### PR TITLE
fix(vllm): Honor text-only sliding-window metadata

### DIFF
--- a/vllm-tensorizer/tests/sm120/README.md
+++ b/vllm-tensorizer/tests/sm120/README.md
@@ -86,3 +86,69 @@ Earlier kernel checks on the documented baseline passed with maximum absolute
 error `7.62939453125e-06` and relative RMSE below `7.3e-08`. The revised probe
 also verifies that the model and allocator actually choose the tested geometry;
 that revision has not yet run on a GPU.
+
+## Text-only attention metadata
+
+The third layer honors `language_model_only` in both the shared sliding-window
+metadata builder and the V4.1 warmup declaration. Text-only prefill needs 128
+indices, not 1152 indices that include unused image slots. This correction is
+not hardware-gated: it honors the same text-only contract on other devices.
+Vision-enabled configuration retains its 1152-index capacity. The vision check
+below tests configuration preservation, not multimodal inference.
+
+```bash
+python3 vllm-tensorizer/tests/sm120/check_sm120_text_only_swa.py --num-tokens 16
+python3 vllm-tensorizer/tests/sm120/check_sm120_text_only_swa.py --num-tokens 65
+python3 vllm-tensorizer/tests/sm120/check_sm120_text_only_swa.py --vision-enabled
+```
+
+The probe exercises the actual metadata builder and public FlashInfer attention
+entrypoint. On the earlier baseline, the unpatched 16-token case failed with
+`ValueError: SM120 sparse-MLA has no decode kernel for this shape` and an index
+width of 1152. With the patch, 16- and 65-token cases used 128 indices and
+passed finite-output and numerical checks. Maximum absolute output error was
+at most `0.0054931640625`, with relative RMSE below `0.025`.
+
+## Earlier full-model configuration
+
+After all three fixes, an earlier native vLLM run passed streaming text,
+separate reasoning, two automatic tool calls, structured JSON, near-limit
+retrieval, and a healthy followup. It used eight RTX PRO 6000 Blackwell Server
+Edition GPUs. The instance SKU was not recorded; the GPU model and topology
+are the available hardware evidence.
+
+The checkpoint was `deepseek-ai/DeepSeek-V4.1-Flash` at
+`fb2764a5cf321eaa5070ca8f9e892818f477c16d`. The earlier command used:
+
+```text
+--language-model-only
+--tokenizer-mode deepseek_v41
+--reasoning-parser deepseek_v41
+--tool-call-parser deepseek_v41
+--enable-auto-tool-choice
+--tensor-parallel-size 8
+--moe-backend marlin
+--max-model-len 262144
+--max-num-seqs 1
+--max-num-batched-tokens 8192
+--gpu-memory-utilization 0.9
+--attention-backend FLASHINFER_MLA_SPARSE_DSV41
+--kv-cache-dtype fp8
+--block-size 128
+--engram-config '{"cpu_offload":true}'
+--prefix-cache-retention-interval 1024
+--generation-config vllm
+--override-generation-config '{"temperature":1.0,"top_p":0.95}'
+--enforce-eager
+```
+
+Native dense layers retained CUTLASS MXFP8; only MoE used Marlin. No dense-GEMM
+fallback or DeepGEMM kernel patch was required. DSpark was disabled.
+
+The long request had 261984 prompt tokens and 27 completion tokens. It returned
+all three records near the start, middle, and end through 26 content chunks,
+then emitted `stop` and `[DONE]`. These synthetic single-sequence results do not
+establish concurrency, broader model quality, multimodal inference, or DSpark
+support. Recheck the CLI and repeat these acceptance checks on the rebuilt
+image; this document records the earlier configuration rather than claiming
+that the new build has passed it.

--- a/vllm-tensorizer/tests/sm120/check_sm120_text_only_swa.py
+++ b/vllm-tensorizer/tests/sm120/check_sm120_text_only_swa.py
@@ -1,0 +1,77 @@
+import argparse
+import json
+from types import SimpleNamespace
+import torch
+from flashinfer.mla import trtllm_batch_decode_sparse_mla_dsv4
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadataBuilder
+from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+from check_sm120_cache_geometry import quantize_kv_dsv4, dequantize_kv_dsv4, _ref_sparse_attn
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--num-tokens', type=int, default=16)
+parser.add_argument('--vision-enabled', action='store_true')
+args = parser.parse_args()
+assert torch.cuda.get_device_capability()[0] == 12
+torch.manual_seed(20260910)
+device = torch.device('cuda')
+config = VllmConfig()
+config.scheduler_config.max_num_batched_tokens = 128
+config.scheduler_config.max_num_seqs = 1
+config.model_config = SimpleNamespace(
+    hf_config=SimpleNamespace(sliding_window=128, vision_max_n_token=1024,
+                              vision_n_layers=8, compress_ratios=[0, 1, 2]),
+    max_model_len=262144,
+    multimodal_config=SimpleNamespace(language_model_only=not args.vision_enabled),
+)
+spec = SlidingWindowMLASpec(block_size=64, num_kv_heads=1, head_size=512,
+                            dtype=torch.uint8, sliding_window=128,
+                            state_content_bytes=584, alignment=576)
+with set_current_vllm_config(config):
+    builder = DeepseekSparseSWAMetadataBuilder(spec, ['test.swa'], config, device)
+    if args.vision_enabled:
+        assert builder.max_image_tokens == 1024
+        assert builder.prefill_index_width == 1152
+        print(json.dumps({'status': 'passed', 'vision_enabled': True, 'index_width': builder.prefill_index_width}))
+        raise SystemExit(0)
+    tokens = args.num_tokens
+    prefix = 144
+    seq_len = prefix + tokens
+    table = torch.tensor([[3, 1, 0, 2]], device=device, dtype=torch.int32)
+    positions = torch.arange(prefix, seq_len, device=device, dtype=torch.int64)
+    slots = table[0, positions // 64].long() * 64 + positions % 64
+    starts_cpu = torch.tensor([0, tokens], dtype=torch.int32)
+    common = CommonAttentionMetadata(
+        query_start_loc=starts_cpu.to(device), query_start_loc_cpu=starts_cpu,
+        seq_lens=torch.tensor([seq_len], device=device, dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([seq_len], dtype=torch.int32),
+        num_reqs=1, num_actual_tokens=tokens, max_query_len=tokens, max_seq_len=seq_len,
+        block_table_tensor=table, slot_mapping=slots, positions=positions,
+    )
+    metadata = builder.build(0, common)
+    indices = metadata.prefill_swa_indices
+    lengths = metadata.prefill_swa_lens
+    print(json.dumps({'stage': 'metadata', 'vision_enabled': False, 'index_width': indices.shape[-1], 'num_tokens': tokens}), flush=True)
+    source = torch.randn(4, 64, 1, 512, device=device, dtype=torch.bfloat16) * 0.5
+    packed = quantize_kv_dsv4(source)
+    dequant = dequantize_kv_dsv4(packed)
+    query = torch.randn(tokens, 8, 512, device=device, dtype=torch.bfloat16) * 0.5
+    sinks = torch.randn(8, device=device)
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device=device)
+    actual = trtllm_batch_decode_sparse_mla_dsv4(
+        query=query, swa_kv_cache=packed, workspace_buffer=workspace,
+        sparse_indices=indices, bmm1_scale=512**-0.5, sinks=sinks,
+        kv_layout='NHD', swa_topk_lens=lengths,
+    )
+    torch.cuda.synchronize()
+    assert builder.max_image_tokens == 0
+    assert indices.shape[-1] == 128
+    assert lengths.max().item() <= 128
+    expected, _ = _ref_sparse_attn(query, dequant, indices.squeeze(1), 512**-0.5, 512, sinks, lengths)
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, expected, atol=0.01, rtol=0.05)
+    error = actual.float() - expected.float()
+    relative_rmse = (error.square().mean() / expected.float().square().mean()).sqrt().item()
+    assert relative_rmse < 0.05
+    print(json.dumps({'status': 'passed', 'num_tokens': tokens, 'index_width': indices.shape[-1], 'max_abs_error': error.abs().max().item(), 'relative_rmse': relative_rmse}), flush=True)

--- a/vllm-tensorizer/vllm-patches/0004-honor-text-only-swa-metadata.patch
+++ b/vllm-tensorizer/vllm-patches/0004-honor-text-only-swa-metadata.patch
@@ -1,0 +1,28 @@
+diff --git a/vllm/models/deepseek_v4_1/attention.py b/vllm/models/deepseek_v4_1/attention.py
+index b3281e3..b56a3da 100644
+--- a/vllm/models/deepseek_v4_1/attention.py
++++ b/vllm/models/deepseek_v4_1/attention.py
+@@ -242,6 +242,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+             if getattr(config, "vision_n_layers", 0) > 0
+             else 0
+         )
++        multimodal_config = vllm_config.model_config.multimodal_config
++        if multimodal_config is not None and multimodal_config.language_model_only:
++            self.max_image_tokens = 0
+         # ---- v4.1 sparse-attention topology ----
+         # compress_ratios has one entry per layer (MTP layers included):
+         # 0 = pure sliding window, 1 = full-length compressed cache,
+diff --git a/vllm/v1/attention/backends/mla/sparse_swa.py b/vllm/v1/attention/backends/mla/sparse_swa.py
+index 02e6336..a9c924d 100644
+--- a/vllm/v1/attention/backends/mla/sparse_swa.py
++++ b/vllm/v1/attention/backends/mla/sparse_swa.py
+@@ -452,6 +452,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
+             if getattr(hf_config, "vision_n_layers", 0) > 0
+             else 0
+         )
++        multimodal_config = self.vllm_config.model_config.multimodal_config
++        if multimodal_config is not None and multimodal_config.language_model_only:
++            self.max_image_tokens = 0
+         self.prefill_index_width = self.window_size + self.max_image_tokens
+ 
+         # Detect which DeepseekV4 layer types this model uses so we only build a


### PR DESCRIPTION
V4.1 checkpoints declare vision layers even when language-model-only is enabled. The shared metadata builder and model warmup still reserve 1024 image indices, producing 1152-wide prefill rows that the SM120 text path rejects. Honor text-only mode in both places so the rows contain the 128 sliding-window indices.

This is the third layer of the separate SM120 draft stack, after #229. The fix is not hardware-gated: it honors the shared text-only contract on all devices and preserves vision-enabled configuration. That broader effect is isolated here for review. It does not change the independent Dynamo frontend stack.

The GPU probe exercises the real metadata builder and public FlashInfer attention entrypoint at 16 and 65 tokens. The vision-enabled case checks configuration preservation only. Documentation includes the earlier public base image, package versions, complete native engine arguments, eight-GPU RTX PRO 6000 Blackwell topology, and near-limit streaming evidence. The instance SKU was not recorded and is not inferred.

Validation: patch application and Python syntax checks pass. Earlier kernel and full-model tests passed on the older documented baseline. The new image build, numerical regression, and full-model acceptance remain pending.

@alexeldeib
