### PR TITLE
fix(sglang): expose system NCCL to DeepEP

### DIFF
--- a/sglang/Dockerfile
+++ b/sglang/Dockerfile
@@ -53,10 +53,20 @@ RUN apt-get -qq update && \
     apt-get -q install --no-install-recommends -y \
       libnvshmem3-cuda-13 \
       libssl-dev && \
+    NCCL_LIB_DIR="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
     NVSHMEM_LIB_DIR="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/nvshmem/13" && \
+    mkdir -p /opt/nccl && \
+    ln -s "${NCCL_LIB_DIR}" /opt/nccl/lib && \
+    ln -s /usr/include /opt/nccl/include && \
     echo "${NVSHMEM_LIB_DIR}" > /etc/ld.so.conf.d/nvshmem.conf && \
     ldconfig && \
     rm -rf /var/lib/apt/lists/*
+
+# sgl-deep-ep discovers NCCL from Python package metadata or this explicit
+# prefix. The base installs NCCL from apt, so expose its multiarch layout under
+# the conventional prefix DeepEP expects without installing a second NCCL copy.
+ENV EP_NCCL_ROOT_DIR=/opt/nccl
+
 RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
     cd /wheels && \
     bash install.bash

--- a/sglang/install.bash
+++ b/sglang/install.bash
@@ -19,6 +19,24 @@ python3 -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__)
   > /etc/ld.so.conf.d/torch.conf
 ldconfig
 
+# Exercise sgl-deep-ep's actual NCCL discovery logic without importing the
+# package, whose top-level GPU prerequisite check cannot run during image build.
+python3 - <<'PY'
+import glob
+import os
+import runpy
+from importlib.metadata import distribution
+
+finder = distribution("sgl-deep-ep").locate_file("deep_ep/utils/find_pkgs.py")
+find_nccl_root = runpy.run_path(str(finder))["find_nccl_root"]
+root = find_nccl_root()
+
+assert os.path.realpath(root) == os.path.realpath(os.environ["EP_NCCL_ROOT_DIR"]), root
+assert glob.glob(os.path.join(root, "lib", "libnccl.so*")), root
+assert os.path.isfile(os.path.join(root, "include", "nccl.h")), root
+print("DeepEP NCCL root:", root)
+PY
+
 # Compile and exercise the lazy HiCache hash extension during the image build.
 # This catches missing C++ headers or libcrypto linkage before request traffic
 # reaches the Mamba radix-cache event path.

--- a/sglang/install.bash
+++ b/sglang/install.bash
@@ -25,16 +25,21 @@ python3 - <<'PY'
 import glob
 import os
 import runpy
-from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError, distribution
 
-finder = distribution("sgl-deep-ep").locate_file("deep_ep/utils/find_pkgs.py")
-find_nccl_root = runpy.run_path(str(finder))["find_nccl_root"]
-root = find_nccl_root()
+try:
+    deep_ep = distribution("sgl-deep-ep")
+except PackageNotFoundError:
+    print("sgl-deep-ep is not installed; skipping its NCCL discovery check")
+else:
+    finder = deep_ep.locate_file("deep_ep/utils/find_pkgs.py")
+    find_nccl_root = runpy.run_path(str(finder))["find_nccl_root"]
+    root = find_nccl_root()
 
-assert os.path.realpath(root) == os.path.realpath(os.environ["EP_NCCL_ROOT_DIR"]), root
-assert glob.glob(os.path.join(root, "lib", "libnccl.so*")), root
-assert os.path.isfile(os.path.join(root, "include", "nccl.h")), root
-print("DeepEP NCCL root:", root)
+    assert os.path.realpath(root) == os.path.realpath(os.environ["EP_NCCL_ROOT_DIR"]), root
+    assert glob.glob(os.path.join(root, "lib", "libnccl.so*")), root
+    assert os.path.isfile(os.path.join(root, "include", "nccl.h")), root
+    print("DeepEP NCCL root:", root)
 PY
 
 # Compile and exercise the lazy HiCache hash extension during the image build.


### PR DESCRIPTION
## Summary

- expose the apt-installed NCCL libraries and headers through a canonical `/opt/nccl` prefix
- set `EP_NCCL_ROOT_DIR=/opt/nccl` for sgl-deep-ep discovery
- add a build-time regression check using DeepEP find_nccl_root logic

## Problem

The SGLang 0.5.19 Dynamo worker exits during `deep_ep` import with:

```
AssertionError: Cannot find package: nccl
```

NCCL 2.30.4 and `libnccl.so` are already installed by the CUDA base through apt. DeepEP 2.1.0 discovers NCCL using an `nvidia-nccl` Python distribution or an explicit root, so it cannot locate the system package without this prefix.

The fix reuses the existing system NCCL installation and does not add a second NCCL version.

## Validation

- `bash -n sglang/install.bash`
- `git diff --check`
- exercised the exact installed DeepEP discovery implementation in the affected image using the proposed prefix
- verified discovery of `libnccl.so`, `libnccl.so.2`, `libnccl.so.2.30.4`, and `nccl.h`

A full top-level DeepEP import requires a GPU and therefore cannot run during the container build; the regression check invokes its discovery module directly without bypassing the code that originally failed.